### PR TITLE
[codex] show runtime memory on run detail page

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -164,6 +164,72 @@ def _build_timeline(run: WorkflowRun) -> list[dict]:
     return points
 
 
+def _build_runtime_memory_sections(run: WorkflowRun) -> list[dict[str, object]]:
+    if not isinstance(run.result, dict):
+        return []
+
+    sections: list[dict[str, object]] = []
+    for key, agent_label in (
+        ("analyst_context", "AnalystAgent"),
+        ("content_context", "ContentAgent"),
+        ("reviewer_context", "ReviewerAgent"),
+    ):
+        context = run.result.get(key)
+        if not isinstance(context, dict):
+            continue
+        memory = context.get("memory", {})
+        if not isinstance(memory, dict):
+            memory = {}
+
+        recent_runs = []
+        for item in memory.get("recent_runs", [])[:3]:
+            if not isinstance(item, dict):
+                continue
+            recent_runs.append(
+                {
+                    "title": item.get("objective", "") or item.get("run_id", ""),
+                    "summary": item.get("summary", ""),
+                    "meta": " / ".join(
+                        str(value)
+                        for value in (item.get("status"), item.get("updated_at"))
+                        if str(value).strip()
+                    ),
+                    "tags": [str(value) for value in item.get("review_reasons", []) if str(value).strip()][:3],
+                }
+            )
+
+        feedback_samples = []
+        for item in memory.get("feedback_samples", [])[:3]:
+            if not isinstance(item, dict):
+                continue
+            feedback_samples.append(
+                {
+                    "reviewer_name": item.get("reviewer_name", ""),
+                    "comment": item.get("comment", ""),
+                    "meta": " / ".join(
+                        str(value)
+                        for value in (item.get("expected_status"), item.get("created_at"))
+                        if str(value).strip()
+                    ),
+                    "keywords": [str(value) for value in item.get("keywords", []) if str(value).strip()][:5],
+                }
+            )
+
+        sections.append(
+            {
+                "agent": agent_label,
+                "memory_hits": int(context.get("memory_hits", 0) or 0),
+                "dominant_keywords": [str(value) for value in memory.get("dominant_keywords", []) if str(value).strip()][:6],
+                "common_review_reasons": [
+                    str(value) for value in memory.get("common_review_reasons", []) if str(value).strip()
+                ][:4],
+                "recent_runs": recent_runs,
+                "feedback_samples": feedback_samples,
+            }
+        )
+    return sections
+
+
 def _build_run_rows(runs: list[WorkflowRun]) -> list[dict]:
     titles = _workflow_titles()
     rows = []
@@ -484,6 +550,7 @@ def run_detail_page(run_id: str, request: Request):
             run=run,
             timeline=_build_timeline(run),
             llm_summary=_build_llm_summary(run),
+            runtime_memory_sections=_build_runtime_memory_sections(run),
             result_json=_pretty_json(run.result),
             graph=engine.graph_shape(),
         ),

--- a/app/services.py
+++ b/app/services.py
@@ -1323,7 +1323,7 @@ class WorkflowEngine:
         run.add_log("ContentAgent", "已补充可直接使用的业务输出。", llm_call=llm_call)
         run.add_log(
             "ContentAgent",
-            f"鍘嗗彶璁板繂宸叉敞鍏?{content_context['memory_hits']} 鏉★紝鐢ㄤ簬鐢熸垚涓氬姟杈撳嚭銆?",
+            f"已注入 {content_context['memory_hits']} 条历史记忆，用于生成业务输出。",
         )
         state["deliverables"] = deliverables
         state["content_context"] = content_context

--- a/app/templates/run_detail.html
+++ b/app/templates/run_detail.html
@@ -116,6 +116,81 @@
   </section>
 </div>
 
+{% if runtime_memory_sections %}
+<section class="card" style="margin-top:18px;">
+  <div class="toolbar" style="justify-content:space-between;">
+    <h2 style="margin:0;">运行时记忆</h2>
+    <span class="badge">{{ runtime_memory_sections|length }} 个 agent context</span>
+  </div>
+  <div class="grid three" style="margin-top:16px;">
+    {% for section in runtime_memory_sections %}
+    <div class="card">
+      <div class="toolbar" style="justify-content:space-between;">
+        <strong>{{ section.agent }}</strong>
+        <span class="badge">memory hits {{ section.memory_hits }}</span>
+      </div>
+
+      {% if section.dominant_keywords %}
+      <div class="subtle" style="margin-top:10px;">高频关键词：{{ section.dominant_keywords | join(" / ") }}</div>
+      {% endif %}
+
+      {% if section.common_review_reasons %}
+      <div class="subtle" style="margin-top:8px;">常见审核原因：{{ section.common_review_reasons | join(" / ") }}</div>
+      {% endif %}
+
+      <details style="margin-top:12px;">
+        <summary>近期运行样本（{{ section.recent_runs|length }}）</summary>
+        {% if section.recent_runs %}
+        <div class="stack" style="margin-top:12px;">
+          {% for row in section.recent_runs %}
+          <div class="card">
+            <strong>{{ row.title }}</strong>
+            {% if row.meta %}<div class="subtle">{{ row.meta }}</div>{% endif %}
+            {% if row.summary %}<div style="margin-top:8px;">{{ row.summary }}</div>{% endif %}
+            {% if row.tags %}
+            <div class="toolbar" style="margin-top:10px;">
+              {% for tag in row.tags %}
+              <span class="badge">{{ tag }}</span>
+              {% endfor %}
+            </div>
+            {% endif %}
+          </div>
+          {% endfor %}
+        </div>
+        {% else %}
+        <div class="subtle" style="margin-top:10px;">暂无近期运行样本。</div>
+        {% endif %}
+      </details>
+
+      <details style="margin-top:12px;">
+        <summary>反馈样本（{{ section.feedback_samples|length }}）</summary>
+        {% if section.feedback_samples %}
+        <div class="stack" style="margin-top:12px;">
+          {% for sample in section.feedback_samples %}
+          <div class="card">
+            <strong>{{ sample.reviewer_name or "匿名审核" }}</strong>
+            {% if sample.meta %}<div class="subtle">{{ sample.meta }}</div>{% endif %}
+            {% if sample.comment %}<div style="margin-top:8px;">{{ sample.comment }}</div>{% endif %}
+            {% if sample.keywords %}
+            <div class="toolbar" style="margin-top:10px;">
+              {% for keyword in sample.keywords %}
+              <span class="badge">{{ keyword }}</span>
+              {% endfor %}
+            </div>
+            {% endif %}
+          </div>
+          {% endfor %}
+        </div>
+        {% else %}
+        <div class="subtle" style="margin-top:10px;">暂无反馈样本。</div>
+        {% endif %}
+      </details>
+    </div>
+    {% endfor %}
+  </div>
+</section>
+{% endif %}
+
 <section class="card" style="margin-top:18px;">
   <h2>结果 JSON</h2>
   <pre>{{ result_json }}</pre>

--- a/docs/superpowers/plans/2026-04-12-runtime-memory-detail-ui.md
+++ b/docs/superpowers/plans/2026-04-12-runtime-memory-detail-ui.md
@@ -1,0 +1,85 @@
+# Runtime Memory Detail UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make runtime memory usage visible on the run detail page and fix the unreadable ContentAgent memory log copy.
+
+**Architecture:** Reuse the existing `run.result` payload as the view model. Add one focused page regression test first, then minimally update the template and the single bad log string in the workflow engine.
+
+**Tech Stack:** FastAPI, Jinja2 templates, pytest, TestClient
+
+---
+
+### Task 1: Lock the UI expectation with a failing page test
+
+**Files:**
+- Modify: `tests/test_workflows.py`
+- Test: `tests/test_workflows.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_run_detail_page_shows_runtime_memory_summary() -> None:
+    first = create_support_run()
+    login_as("reviewer", "reviewer123")
+    approved = client.post(
+        f"/api/workflows/{first['id']}/review",
+        json={"approve": True, "comment": "keep owner and risk notes"},
+    )
+    assert approved.status_code == 200
+
+    second = create_support_run()
+
+    detail = client.get(f"/runs/{second['id']}")
+
+    assert detail.status_code == 200
+    assert "运行时记忆" in detail.text
+    assert "AnalystAgent" in detail.text
+    assert "ContentAgent" in detail.text
+    assert "ReviewerAgent" in detail.text
+    assert "memory hits" in detail.text
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_workflows.py -k run_detail_page_shows_runtime_memory_summary -q`
+Expected: FAIL because the current template does not render the runtime memory section.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Update the run detail template to render a runtime memory section from `run.result`, and fix the `ContentAgent` log string in `app/services.py`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_workflows.py -k run_detail_page_shows_runtime_memory_summary -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-04-12-runtime-memory-detail-ui-design.md docs/superpowers/plans/2026-04-12-runtime-memory-detail-ui.md tests/test_workflows.py app/templates/run_detail.html app/services.py
+git commit -m "feat: show runtime memory on run detail page"
+```
+
+### Task 2: Verify the integrated flow
+
+**Files:**
+- Modify: `app/templates/run_detail.html`
+- Modify: `app/services.py`
+- Test: `tests/test_workflows.py`
+
+- [ ] **Step 1: Run the focused workflow test slice**
+
+Run: `python -m pytest tests/test_workflows.py -k "runtime_memory or run_detail_page" -q`
+Expected: PASS
+
+- [ ] **Step 2: Run the full suite**
+
+Run: `python -m pytest -q`
+Expected: PASS
+
+- [ ] **Step 3: Inspect git diff**
+
+Run: `git diff -- app/templates/run_detail.html app/services.py tests/test_workflows.py`
+Expected: only the detail UI, the log copy, and test coverage changed.
+

--- a/docs/superpowers/specs/2026-04-12-runtime-memory-detail-ui-design.md
+++ b/docs/superpowers/specs/2026-04-12-runtime-memory-detail-ui-design.md
@@ -1,0 +1,36 @@
+# Runtime Memory Detail UI Design
+
+## Goal
+
+Expose runtime memory usage on the run detail page so operators and reviewers can see which agents used historical context, how many memory hits were injected, and a compact summary of the related runs and feedback samples without digging through raw JSON.
+
+## Scope
+
+- Add a dedicated runtime memory section to the run detail page.
+- Show `analyst_context`, `content_context`, and `reviewer_context` when present.
+- Surface memory hit counts and compact rows for recent runs and feedback samples.
+- Fix the garbled `ContentAgent` memory log message so timeline text is readable.
+- Add page-level regression coverage.
+
+## Non-Goals
+
+- No new memory retrieval logic.
+- No export/report format changes.
+- No `MemoryService` refactor in this slice.
+
+## Design
+
+The page will keep using `run.result` as the source of truth. The template will render a new runtime memory section only when at least one agent context exists. Each agent gets a compact card with:
+
+- memory hit count
+- dominant keywords / common review reasons when available
+- recent run summaries
+- recent feedback summaries
+
+The UI stays read-only and follows the existing card/grid pattern in the current run detail template. This keeps the change small and avoids new route or serializer logic.
+
+## Test Strategy
+
+- Add a failing page test that creates memory-bearing workflow runs and asserts the run detail page shows the runtime memory section plus agent labels and hit counts.
+- Keep existing workflow memory tests intact.
+

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -400,7 +400,28 @@ def test_runtime_memory_context_is_recorded_for_content_agent() -> None:
     assert content_context["memory_hits"] >= 1
     assert len(content_context["memory"]["recent_runs"]) >= 1
     assert len(content_context["memory"]["feedback_samples"]) >= 1
-    assert any("鍘嗗彶璁板繂" in log["message"] for log in second["logs"] if log["agent"] == "ContentAgent")
+    assert any("历史记忆" in log["message"] for log in second["logs"] if log["agent"] == "ContentAgent")
+
+
+def test_run_detail_page_shows_runtime_memory_summary() -> None:
+    first = create_support_run()
+    login_as("reviewer", "reviewer123")
+    reviewed = client.post(
+        f"/api/workflows/{first['id']}/review",
+        json={"approve": True, "comment": "keep owner and risk notes"},
+    )
+    assert reviewed.status_code == 200
+
+    second = create_support_run()
+
+    detail = client.get(f"/runs/{second['id']}")
+
+    assert detail.status_code == 200
+    assert "运行时记忆" in detail.text
+    assert "AnalystAgent" in detail.text
+    assert "ContentAgent" in detail.text
+    assert "ReviewerAgent" in detail.text
+    assert "memory hits" in detail.text
 
 
 def test_settings_can_disable_runtime_memory(monkeypatch) -> None:


### PR DESCRIPTION
﻿## Summary
- show runtime memory summaries for AnalystAgent, ContentAgent, and ReviewerAgent on the run detail page
- fix the garbled ContentAgent runtime-memory log message so timeline output stays readable
- add a run-detail regression test plus concise design/plan docs for this follow-up

## Why
Issue #9 tracks the main remaining UX gap after runtime memory was merged into main: the data exists in `run.result`, but operators still have to inspect raw JSON to understand what memory was used.

## Test Plan
- python -m pytest tests/test_workflows.py -k "runtime_memory or run_detail_page" -q
- python -m pytest -q

Closes #9
