### PR TITLE
[codex] add dynamic agent router

### DIFF
--- a/app/services.py
+++ b/app/services.py
@@ -57,6 +57,10 @@ class WorkflowState(TypedDict, total=False):
     request: WorkflowRequest
     execution_profile: ExecutionProfile
     prompt_profile: PromptProfile
+    last_node: str
+    next_node: str
+    replan_count: int
+    route_decisions: list[dict[str, Any]]
     planning_context: dict[str, Any]
     analyst_context: dict[str, Any]
     content_context: dict[str, Any]
@@ -499,18 +503,18 @@ class PlannerAgent:
         fallback = self._fallback_plan(request)
         planning_context, tool_call = self.planning_context_tool.run(request)
         system_prompt = (
-            "你是企业 AI 工作流中的 PlannerAgent。"
-            "请结合任务输入、工作流模板和历史经验，输出一个结构化执行计划。"
-            "必须返回 JSON，键为 workflow_type、objective、steps、expected_outputs。"
-            "steps 需要可执行且有顺序，expected_outputs 需要与后续 agent 的产出一致。"
+            "???? AI ????? PlannerAgent?"
+            "???????????????????????????????"
+            "???? JSON??? workflow_type?objective?steps?expected_outputs?"
+            "steps ??????????expected_outputs ????? agent ??????"
         )
         user_prompt = (
-            f"当前 Prompt 方案：{prompt_profile.name} {prompt_profile.version}\n"
-            f"方案描述：{prompt_profile.description}\n"
-            f"工作流类型：{request.workflow_type.value}\n"
-            f"任务输入 JSON：\n{json.dumps(request.input_payload, ensure_ascii=False)}\n"
-            f"规划上下文工具结果 JSON：\n{json.dumps(planning_context, ensure_ascii=False)}\n"
-            "请生成适合当前任务的规划，若历史反馈里出现风险或缺口，请在 objective 或 steps 中体现。"
+            f"?? Prompt ???{prompt_profile.name} {prompt_profile.version}\n"
+            f"?????{prompt_profile.description}\n"
+            f"??????{request.workflow_type.value}\n"
+            f"???? JSON?\n{json.dumps(request.input_payload, ensure_ascii=False)}\n"
+            f"????????? JSON?\n{json.dumps(planning_context, ensure_ascii=False)}\n"
+            "????????????????????????????? objective ? steps ????"
         )
         response = self.llm_service.generate_json(
             route_target="planner",
@@ -581,12 +585,12 @@ class PlannerAgent:
     @staticmethod
     def _objective(workflow_type: WorkflowType, payload: dict[str, Any]) -> str:
         if workflow_type == WorkflowType.SALES_FOLLOWUP:
-            return f"分析 {payload.get('period', '当前周期')} 在 {payload.get('region', '全部区域')} 的销售表现"
+            return f"?? {payload.get('period', '????')} ? {payload.get('region', '????')} ?????"
         if workflow_type == WorkflowType.MARKETING_CAMPAIGN:
-            return f"为 {payload.get('product_name', '目标产品')} 生成投放内容"
+            return f"? {payload.get('product_name', '????')} ??????"
         if workflow_type == WorkflowType.SUPPORT_TRIAGE:
-            return f"处理 {len(payload.get('tickets', []))} 条客服工单"
-        return f"将 {payload.get('meeting_title', '会议')} 纪要转成执行动作"
+            return f"?? {len(payload.get('tickets', []))} ?????"
+        return f"? {payload.get('meeting_title', '??')} ????????"
 
 
 class ToolCenter:
@@ -637,16 +641,16 @@ class ToolCenter:
         channels = payload.get("channels", ["xiaohongshu"])
         key_benefits = payload.get("key_benefits", [])
         return {
-            "product_name": payload.get("product_name", "目标产品"),
-            "audience": payload.get("audience", "目标人群"),
+            "product_name": payload.get("product_name", "????"),
+            "audience": payload.get("audience", "????"),
             "channels": channels,
             "key_benefits": key_benefits,
-            "tone": payload.get("tone", "清晰直接"),
+            "tone": payload.get("tone", "????"),
             "compliance_risks": [
-                "避免使用绝对化效果承诺",
-                "发布前复核产品能力表述",
+                "???????????",
+                "???????????",
             ],
-            "channel_notes": {channel: f"为 {channel} 准备一个主卖点和一个行动号召" for channel in channels},
+            "channel_notes": {channel: f"? {channel} ??????????????" for channel in channels},
         }
 
     def _support_triage(self, payload: dict[str, Any]) -> tuple[dict[str, Any], str]:
@@ -683,7 +687,7 @@ class ToolCenter:
             enriched.append(
                 {
                     "ticket_id": str(ticket.get("source_id") or f"T-{index:03d}"),
-                    "customer": ticket.get("customer", f"客户{index}"),
+                    "customer": ticket.get("customer", f"??{index}"),
                     "category": category,
                     "priority": severity,
                     "message": ticket.get("message", ""),
@@ -706,17 +710,17 @@ class ToolCenter:
         sentences = [item.strip(" .") for item in re.split(r"\d+\.\s*", notes) if item.strip()]
         actions = []
         for index, sentence in enumerate(sentences, start=1):
-            owner = sentence.split(" ", 1)[0] if sentence else f"负责人{index}"
+            owner = sentence.split(" ", 1)[0] if sentence else f"???{index}"
             actions.append(
                 {
                     "id": f"A-{index:03d}",
                     "owner": owner,
                     "task": sentence,
-                    "deadline": "下个检查点",
+                    "deadline": "?????",
                 }
             )
         return {
-            "meeting_title": payload.get("meeting_title", "会议"),
+            "meeting_title": payload.get("meeting_title", "??"),
             "action_items": actions,
             "owner_count": len({item["owner"] for item in actions}),
             "summary_points": sentences[:3],
@@ -738,13 +742,13 @@ class AnalystAgent:
     ) -> tuple[dict[str, Any], Any]:
         fallback = self._fallback_analysis(request.workflow_type, raw_result)
         system_prompt = (
-            "你是企业 AI 工作流中的 AnalystAgent。请严格返回 JSON，键为 summary、insights、action_plan，全部使用中文。"
+            "???? AI ????? AnalystAgent?????? JSON??? summary?insights?action_plan????????"
         )
         user_prompt = (
-            f"Prompt 方案要求：{prompt_profile.analyst_instruction}\n"
-            f"工作流类型：{request.workflow_type.value}\n"
-            f"原始结果 JSON：\n{json.dumps(raw_result, ensure_ascii=False)}\n"
-            f"历史记忆 JSON：\n{json.dumps(memory_context, ensure_ascii=False)}"
+            f"Prompt ?????{prompt_profile.analyst_instruction}\n"
+            f"??????{request.workflow_type.value}\n"
+            f"???? JSON?\n{json.dumps(raw_result, ensure_ascii=False)}\n"
+            f"???? JSON?\n{json.dumps(memory_context, ensure_ascii=False)}"
         )
         response = self.llm_service.generate_json(
             route_target="analyst",
@@ -763,53 +767,53 @@ class AnalystAgent:
     @staticmethod
     def _fallback_analysis(workflow_type: WorkflowType, raw_result: dict[str, Any]) -> dict[str, Any]:
         if workflow_type == WorkflowType.SALES_FOLLOWUP:
-            risk_names = "、".join(item["name"] for item in raw_result.get("risk_customers", [])) or "暂无"
+            risk_names = "?".join(item["name"] for item in raw_result.get("risk_customers", [])) or "??"
             return {
                 "summary": (
-                    f"当前转化率为 {raw_result.get('conversion_rate', 0):.0%}，平均销售周期 {raw_result.get('avg_cycle_days', 0)} 天。"
+                    f"?????? {raw_result.get('conversion_rate', 0):.0%}??????? {raw_result.get('avg_cycle_days', 0)} ??"
                 ),
                 "insights": [
-                    "整体转化表现偏弱，风险客户需要重点跟进。",
-                    f"当前风险客户包括：{risk_names}。",
+                    "????????????????????",
+                    f"?????????{risk_names}?",
                 ],
                 "action_plan": [
-                    "为风险客户制定一对一跟进计划。",
-                    "与区域负责人复盘停滞商机。",
+                    "???????????????",
+                    "?????????????",
                 ],
             }
         if workflow_type == WorkflowType.MARKETING_CAMPAIGN:
             return {
-                "summary": f"已为 {raw_result.get('product_name', '产品')} 准备投放内容方案。",
+                "summary": f"?? {raw_result.get('product_name', '??')} ?????????",
                 "insights": [
-                    "不同渠道需要统一卖点但单独设计行动号召。",
-                    "发布前需要复核合规表述。",
+                    "????????????????????",
+                    "????????????",
                 ],
                 "action_plan": [
-                    "为每个渠道明确主卖点。",
-                    "上线前增加一次合规检查。",
+                    "???????????",
+                    "????????????",
                 ],
             }
         if workflow_type == WorkflowType.SUPPORT_TRIAGE:
             return {
-                "summary": f"当前有 {raw_result.get('high_priority_count', 0)} 条高优先级工单需要优先处理。",
+                "summary": f"??? {raw_result.get('high_priority_count', 0)} ??????????????",
                 "insights": [
-                    "疑似故障类工单应优先进入人工接管。",
-                    "低风险账单类问题可自动生成回复草稿。",
+                    "?????????????????",
+                    "??????????????????",
                 ],
                 "action_plan": [
-                    "将故障工单升级给值班负责人。",
-                    "为低风险工单发送标准回复草稿。",
+                    "??????????????",
+                    "???????????????",
                 ],
             }
         return {
-            "summary": f"已抽取 {len(raw_result.get('action_items', []))} 条会议行动项。",
+            "summary": f"??? {len(raw_result.get('action_items', []))} ???????",
             "insights": [
-                "每个行动项都需要明确责任人和检查节点。",
-                "简洁总结更利于团队快速执行。",
+                "???????????????????",
+                "??????????????",
             ],
             "action_plan": [
-                "将行动项同步给对应负责人。",
-                "自动完成前复核截止时间是否清晰。",
+                "?????????????",
+                "????????????????",
             ],
         }
 
@@ -830,15 +834,15 @@ class ContentAgent:
     ) -> tuple[dict[str, Any], Any]:
         fallback = self._fallback_deliverables(request.workflow_type, raw_result, analysis)
         system_prompt = (
-            "你是企业 AI 工作流中的 ContentAgent。请严格返回 JSON，键为 deliverables 和 manager_note，全部使用中文。"
+            "???? AI ????? ContentAgent?????? JSON??? deliverables ? manager_note????????"
         )
         user_prompt = (
-            f"Prompt 方案要求：{prompt_profile.content_instruction}\n"
-            f"工作流类型：{request.workflow_type.value}\n"
-            f"原始结果 JSON：\n{json.dumps(raw_result, ensure_ascii=False)}\n"
-            f"分析结果 JSON：\n{json.dumps(analysis, ensure_ascii=False)}"
+            f"Prompt ?????{prompt_profile.content_instruction}\n"
+            f"??????{request.workflow_type.value}\n"
+            f"???? JSON?\n{json.dumps(raw_result, ensure_ascii=False)}\n"
+            f"???? JSON?\n{json.dumps(analysis, ensure_ascii=False)}"
         )
-        user_prompt += f"\n鍘嗗彶璁板繂 JSON锛歕n{json.dumps(memory_context, ensure_ascii=False)}"
+        user_prompt += f"\n?????? JSON??n{json.dumps(memory_context, ensure_ascii=False)}"
         response = self.llm_service.generate_json(
             route_target="content",
             system_prompt=system_prompt,
@@ -860,43 +864,43 @@ class ContentAgent:
     ) -> dict[str, Any]:
         if workflow_type == WorkflowType.SALES_FOLLOWUP:
             deliverables = {
-                "日报摘要": analysis.get("summary", ""),
+                "????": analysis.get("summary", ""),
                 "follow_up_plan": [
                     {
-                        "客户": item["name"],
-                        "负责人": item["owner"],
-                        "下一步动作": item["next_action"],
+                        "??": item["name"],
+                        "???": item["owner"],
+                        "?????": item["next_action"],
                     }
                     for item in raw_result.get("risk_customers", [])
                 ],
             }
-            manager_note = "需要管理者确认风险客户跟进节奏和较长销售周期的处理策略。"
+            manager_note = "????????????????????????????"
         elif workflow_type == WorkflowType.MARKETING_CAMPAIGN:
             deliverables = {
-                "渠道内容资产": {
-                    channel: f"{raw_result.get('product_name', '产品')} 面向 {raw_result.get('audience', '目标用户')} 的 {channel} 投放文案"
+                "??????": {
+                    channel: f"{raw_result.get('product_name', '??')} ?? {raw_result.get('audience', '????')} ? {channel} ????"
                     for channel in raw_result.get("channels", [])
                 },
-                "发布检查清单": raw_result.get("compliance_risks", []),
+                "??????": raw_result.get("compliance_risks", []),
             }
-            manager_note = "排期前建议先完成一次合规复核。"
+            manager_note = "???????????????"
         elif workflow_type == WorkflowType.SUPPORT_TRIAGE:
             deliverables = {
-                "回复草稿": [
+                "????": [
                     {
-                        "工单编号": item["ticket_id"],
-                        "草稿": f"我们已收到关于{item['category']}的问题，正在为您进一步处理，请稍候。",
+                        "????": item["ticket_id"],
+                        "??": f"???????{item['category']}??????????????????",
                     }
                     for item in raw_result.get("tickets", [])
                 ]
             }
-            manager_note = "高优先级故障工单应由人工负责人复核。"
+            manager_note = "??????????????????"
         else:
             deliverables = {
-                "会后摘要邮件": analysis.get("summary", ""),
-                "行动项": raw_result.get("action_items", []),
+                "??????": analysis.get("summary", ""),
+                "???": raw_result.get("action_items", []),
             }
-            manager_note = "建议将行动摘要同步给负责人并确认截止时间。"
+            manager_note = "?????????????????????"
         return {"deliverables": deliverables, "manager_note": manager_note}
 
 
@@ -917,15 +921,15 @@ class ReviewerAgent:
     ) -> tuple[dict[str, Any], Any]:
         fallback = self._rule_review(request.workflow_type, raw_result, analysis, deliverables)
         system_prompt = (
-            "你是企业 AI 工作流中的 ReviewerAgent。请严格返回 JSON，键为 status、needs_human_review、score、reasons，全部使用中文。"
+            "???? AI ????? ReviewerAgent?????? JSON??? status?needs_human_review?score?reasons????????"
         )
         user_prompt = (
-            f"Prompt 方案要求：{prompt_profile.reviewer_instruction}\n"
-            f"工作流类型：{request.workflow_type.value}\n"
-            f"原始结果 JSON：\n{json.dumps(raw_result, ensure_ascii=False)}\n"
-            f"分析结果 JSON：\n{json.dumps(analysis, ensure_ascii=False)}\n"
-            f"交付结果 JSON：\n{json.dumps(deliverables, ensure_ascii=False)}\n"
-            f"历史记忆 JSON：\n{json.dumps(memory_context, ensure_ascii=False)}"
+            f"Prompt ?????{prompt_profile.reviewer_instruction}\n"
+            f"??????{request.workflow_type.value}\n"
+            f"???? JSON?\n{json.dumps(raw_result, ensure_ascii=False)}\n"
+            f"???? JSON?\n{json.dumps(analysis, ensure_ascii=False)}\n"
+            f"???? JSON?\n{json.dumps(deliverables, ensure_ascii=False)}\n"
+            f"???? JSON?\n{json.dumps(memory_context, ensure_ascii=False)}"
         )
         response = self.llm_service.generate_json(
             route_target="reviewer",
@@ -951,31 +955,31 @@ class ReviewerAgent:
         if workflow_type == WorkflowType.SALES_FOLLOWUP:
             if raw_result.get("conversion_rate", 0) <= 0.15:
                 needs_human_review = True
-                reasons.append("当前转化率偏低，跟进策略需要管理者确认。")
+                reasons.append("????????????????????")
                 score = 0.65
             if raw_result.get("risk_customers"):
-                reasons.append("风险客户需要明确负责人和跟进节奏。")
+                reasons.append("?????????????????")
         elif workflow_type == WorkflowType.MARKETING_CAMPAIGN:
             needs_human_review = True
-            reasons.append("营销内容需要人工复核品牌口径和合规表达。")
+            reasons.append("????????????????????")
             score = 0.7
         elif workflow_type == WorkflowType.SUPPORT_TRIAGE:
             if raw_result.get("requires_incident_handoff"):
                 needs_human_review = True
-                reasons.append("疑似故障类工单必须进入人工接管。")
+                reasons.append("????????????????")
                 score = 0.6
         elif workflow_type == WorkflowType.MEETING_MINUTES:
             if not raw_result.get("action_items"):
                 needs_human_review = True
-                reasons.append("当前未抽取到清晰的行动项，需要人工确认。")
+                reasons.append("????????????????????")
                 score = 0.55
 
         if not reasons:
-            reasons.append("结果结构完整，可直接流转执行。")
+            reasons.append("???????????????")
         if not analysis or not deliverables:
             needs_human_review = True
             score = min(score, 0.5)
-            reasons.append("核心分析或交付结果不完整，需要人工补充。")
+            reasons.append("????????????????????")
         status = "waiting_human" if needs_human_review else "completed"
         return {
             "status": status,
@@ -1007,18 +1011,18 @@ class ReviewerAgent:
                 reason for reason in reasons
                 if not any(
                     text in reason.lower()
-                    for text in ["proceed automatically", "auto-complete", "can proceed directly", "直接流转", "自动流转"]
+                    for text in ["proceed automatically", "auto-complete", "can proceed directly", "????", "????"]
                 )
             ]
             if not reasons:
-                reasons = ["该任务需要人工审核后才能继续执行。"]
+                reasons = ["?????????????????"]
         else:
             reasons = [
                 reason for reason in reasons
                 if "human review" not in reason.lower() and "handoff" not in reason.lower()
             ]
             if not reasons:
-                reasons = ["结果完整且风险可控，可以直接自动流转。"]
+                reasons = ["???????????????????"]
 
         score = float(model_review.get("score", rule_review.get("score", 0.8)))
         if status == "waiting_human":
@@ -1029,6 +1033,56 @@ class ReviewerAgent:
             "score": round(score, 2),
             "reasons": reasons,
         }
+
+
+class RouterAgent:
+    def decide(self, *, last_node: str, state: dict[str, Any]) -> dict[str, Any]:
+        replan_count = int(state.get("replan_count", 0) or 0)
+        next_node = "complete_run"
+        reason = "workflow state is complete"
+
+        if last_node == "planner":
+            next_node = "operator"
+            reason = "plan is ready; collect or transform source data"
+        elif last_node == "operator":
+            next_node = "analyst"
+            reason = "raw tool result is available for analysis"
+        elif last_node == "analyst":
+            next_node = "content"
+            reason = "analysis is available for deliverable generation"
+        elif last_node == "content":
+            deliverables = state.get("deliverables", {})
+            if self._missing_deliverables(deliverables) and replan_count < 1:
+                next_node = "planner"
+                replan_count += 1
+                reason = "deliverables are missing; request one replanning pass"
+            else:
+                next_node = "reviewer"
+                reason = "deliverables are ready for review"
+        elif last_node == "reviewer":
+            review = state.get("review", {})
+            if isinstance(review, dict) and review.get("status") == "waiting_human":
+                next_node = "handoff_run"
+                reason = "review requires human handoff"
+            else:
+                next_node = "complete_run"
+                reason = "review approved automatic completion"
+
+        return {
+            "from_node": last_node,
+            "next_node": next_node,
+            "reason": reason,
+            "replan_count": replan_count,
+        }
+
+    @staticmethod
+    def _missing_deliverables(deliverables: Any) -> bool:
+        if not isinstance(deliverables, dict) or not deliverables:
+            return True
+        nested = deliverables.get("deliverables")
+        if isinstance(nested, dict):
+            return not bool(nested)
+        return False
 
 
 class FeedbackService:
@@ -1070,22 +1124,22 @@ class FeedbackService:
                 seen.append(cleaned)
         if seen:
             return seen[:8]
-        return ["人工审核", "质量复核", "执行清晰"]
+        return ["????", "????", "????"]
 
     @staticmethod
     def _extract_quality_tags(run: WorkflowRun, comment: str) -> list[str]:
         tags = [run.workflow_type.value]
         text = f"{comment} {' '.join(run.review.reasons if run.review else [])}"
-        if "风险" in text or "incident" in text.lower():
-            tags.append("风险控制")
-        if "负责人" in text or "owner" in text.lower():
-            tags.append("责任清晰")
-        if "合规" in text:
-            tags.append("合规复核")
+        if "??" in text or "incident" in text.lower():
+            tags.append("????")
+        if "???" in text or "owner" in text.lower():
+            tags.append("????")
+        if "??" in text:
+            tags.append("????")
         if run.status == RunStatus.COMPLETED:
-            tags.append("可执行")
+            tags.append("???")
         else:
-            tags.append("需人工判断")
+            tags.append("?????")
         return tags
 
     @staticmethod
@@ -1095,7 +1149,7 @@ class FeedbackService:
             "completeness_weight": 35,
             "risk_control_weight": 30,
             "workflow_type": run.workflow_type.value,
-            "guide": "重点检查输出是否清晰、完整、可执行，并根据场景确认风险是否被正确识别。",
+            "guide": "???????????????????????????????????",
         }
 
 
@@ -1113,6 +1167,7 @@ class WorkflowEngine:
         self.analyst_agent = AnalystAgent(self.llm_service)
         self.content_agent = ContentAgent(self.llm_service)
         self.reviewer_agent = ReviewerAgent(self.llm_service)
+        self.router_agent = RouterAgent()
         self.feedback_service = FeedbackService(repository)
         self.graph = self._build_graph()
 
@@ -1166,6 +1221,8 @@ class WorkflowEngine:
             "request": request,
             "execution_profile": execution_profile,
             "prompt_profile": prompt_profile,
+            "replan_count": 0,
+            "route_decisions": [],
             "persist": persist,
         }
         try:
@@ -1193,7 +1250,7 @@ class WorkflowEngine:
         )
         run.add_log(
             "HumanReviewer",
-            f"{reviewer_name}{'已通过' if submission.approve else '已驳回'}该任务。备注：{submission.comment or '无'}",
+            f"{reviewer_name}{'???' if submission.approve else '???'}???????{submission.comment or '?'}",
         )
         if run.review:
             run.review.status = run.status
@@ -1208,15 +1265,21 @@ class WorkflowEngine:
     def graph_shape() -> dict[str, Any]:
         return {
             "runtime": "langgraph",
-            "nodes": ["planner", "operator", "analyst", "content", "reviewer", "complete_run", "handoff_run"],
+            "nodes": ["planner", "operator", "analyst", "content", "reviewer", "router", "complete_run", "handoff_run"],
             "edges": [
                 {"from": "start", "to": "planner"},
-                {"from": "planner", "to": "operator"},
-                {"from": "operator", "to": "analyst"},
-                {"from": "analyst", "to": "content"},
-                {"from": "content", "to": "reviewer"},
-                {"from": "reviewer", "to": "complete_run"},
-                {"from": "reviewer", "to": "handoff_run"},
+                {"from": "planner", "to": "router"},
+                {"from": "operator", "to": "router"},
+                {"from": "analyst", "to": "router"},
+                {"from": "content", "to": "router"},
+                {"from": "reviewer", "to": "router"},
+                {"from": "router", "to": "operator"},
+                {"from": "router", "to": "analyst"},
+                {"from": "router", "to": "content"},
+                {"from": "router", "to": "planner"},
+                {"from": "router", "to": "reviewer"},
+                {"from": "router", "to": "complete_run"},
+                {"from": "router", "to": "handoff_run"},
             ],
         }
 
@@ -1227,17 +1290,27 @@ class WorkflowEngine:
         graph.add_node("analyst", self._analyst_step)
         graph.add_node("content", self._content_step)
         graph.add_node("reviewer", self._reviewer_step)
+        graph.add_node("router", self._router_step)
         graph.add_node("complete_run", self._complete_step)
         graph.add_node("handoff_run", self._handoff_step)
         graph.add_edge(START, "planner")
-        graph.add_edge("planner", "operator")
-        graph.add_edge("operator", "analyst")
-        graph.add_edge("analyst", "content")
-        graph.add_edge("content", "reviewer")
+        graph.add_edge("planner", "router")
+        graph.add_edge("operator", "router")
+        graph.add_edge("analyst", "router")
+        graph.add_edge("content", "router")
+        graph.add_edge("reviewer", "router")
         graph.add_conditional_edges(
-            "reviewer",
-            self._route_after_review,
-            {"complete_run": "complete_run", "handoff_run": "handoff_run"},
+            "router",
+            self._route_from_router,
+            {
+                "planner": "planner",
+                "operator": "operator",
+                "analyst": "analyst",
+                "content": "content",
+                "reviewer": "reviewer",
+                "complete_run": "complete_run",
+                "handoff_run": "handoff_run",
+            },
         )
         graph.add_edge("complete_run", END)
         graph.add_edge("handoff_run", END)
@@ -1257,10 +1330,11 @@ class WorkflowEngine:
         state["planning_context"] = planning_context
         run.add_log(
             "PlannerAgent",
-            f"已生成动态执行计划，共 {len(plan.steps)} 步，并注入规划上下文与历史记忆。",
+            f"??????????? {len(plan.steps)} ????????????????",
             tool_call=tool_call,
             llm_call=llm_call,
         )
+        state["last_node"] = "planner"
         return state
 
     def _operator_step(self, state: WorkflowState) -> WorkflowState:
@@ -1268,8 +1342,9 @@ class WorkflowEngine:
         request = state["request"]
         run.touch(status=RunStatus.EXECUTING, current_step="operator")
         raw_result, tool_call = self.tool_center.run(request.workflow_type, request.input_payload)
-        run.add_log("OperatorAgent", f"已完成工具调用：{tool_call.name}。", tool_call=tool_call)
+        run.add_log("OperatorAgent", f"????????{tool_call.name}?", tool_call=tool_call)
         state["raw_result"] = raw_result
+        state["last_node"] = "operator"
         return state
 
     def _analyst_step(self, state: WorkflowState) -> WorkflowState:
@@ -1293,11 +1368,12 @@ class WorkflowEngine:
         )
         run.add_log(
             "AnalystAgent",
-            f"已完成结果分析与行动建议整理，并注入 {analyst_context['memory_hits']} 条历史记忆。",
+            f"?????????????????? {analyst_context['memory_hits']} ??????",
             llm_call=llm_call,
         )
         state["analysis"] = analysis
         state["analyst_context"] = analyst_context
+        state["last_node"] = "analyst"
         return state
 
     def _content_step(self, state: WorkflowState) -> WorkflowState:
@@ -1320,13 +1396,14 @@ class WorkflowEngine:
             execution_profile=state["execution_profile"],
             prompt_profile=state["prompt_profile"],
         )
-        run.add_log("ContentAgent", "已补充可直接使用的业务输出。", llm_call=llm_call)
+        run.add_log("ContentAgent", "??????????????", llm_call=llm_call)
         run.add_log(
             "ContentAgent",
-            f"已注入 {content_context['memory_hits']} 条历史记忆，用于生成业务输出。",
+            f"??? {content_context['memory_hits']} ???????????????",
         )
         state["deliverables"] = deliverables
         state["content_context"] = content_context
+        state["last_node"] = "content"
         return state
 
     def _reviewer_step(self, state: WorkflowState) -> WorkflowState:
@@ -1358,6 +1435,7 @@ class WorkflowEngine:
             "analyst_context": state.get("analyst_context", {}),
             "content_context": state.get("content_context", {}),
             "reviewer_context": reviewer_context,
+            "route_decisions": state.get("route_decisions", []),
             "raw_result": state["raw_result"],
             "analysis": state["analysis"],
             "deliverables": state["deliverables"],
@@ -1366,19 +1444,32 @@ class WorkflowEngine:
         }
         run.add_log(
             "ReviewerAgent",
-            f"已完成审核判断，并注入 {reviewer_context['memory_hits']} 条历史记忆。",
+            f"??????????? {reviewer_context['memory_hits']} ??????",
             llm_call=llm_call,
         )
         state["review"] = review_payload
         state["reviewer_context"] = reviewer_context
+        state["last_node"] = "reviewer"
+        return state
+
+    def _router_step(self, state: WorkflowState) -> WorkflowState:
+        run = state["run"]
+        last_node = state.get("last_node", "planner")
+        decision = self.router_agent.decide(last_node=last_node, state=dict(state))
+        state["next_node"] = str(decision["next_node"])
+        state["replan_count"] = int(decision["replan_count"])
+        route_decisions = list(state.get("route_decisions", []))
+        route_decisions.append(decision)
+        state["route_decisions"] = route_decisions
+        run.add_log(
+            "RouterAgent",
+            f"? {decision['from_node']} ??? {decision['next_node']}?{decision['reason']}",
+        )
         return state
 
     @staticmethod
-    def _route_after_review(state: WorkflowState) -> str:
-        review = state.get("review") or {}
-        if review.get("status") == "waiting_human":
-            return "handoff_run"
-        return "complete_run"
+    def _route_from_router(state: WorkflowState) -> str:
+        return state.get("next_node", "complete_run")
 
     def _complete_step(self, state: WorkflowState) -> WorkflowState:
         run = state["run"]
@@ -1386,7 +1477,8 @@ class WorkflowEngine:
         if run.review:
             run.review.status = RunStatus.COMPLETED
             run.review.needs_human_review = False
-        run.add_log("System", "工作流已自动完成。")
+        run.add_log("System", "?????????")
+        run.result["route_decisions"] = state.get("route_decisions", [])
         run.result["metrics"] = summarize_run_metrics(run)
         return state
 
@@ -1396,7 +1488,8 @@ class WorkflowEngine:
         if run.review:
             run.review.status = RunStatus.WAITING_HUMAN
             run.review.needs_human_review = True
-        run.add_log("System", "工作流已进入人工审核。")
+        run.add_log("System", "???????????")
+        run.result["route_decisions"] = state.get("route_decisions", [])
         run.result["metrics"] = summarize_run_metrics(run)
         return state
 
@@ -1413,8 +1506,8 @@ class EvaluationService:
             base.append(
                 {
                     "dataset_id": "feedback-loop-v1",
-                    "name": "人工反馈闭环集",
-                    "description": "由人工审核结果自动沉淀生成的样本集。",
+                    "name": "???????",
+                    "description": "??????????????????",
                     "case_count": str(len(samples)),
                 }
             )
@@ -1534,7 +1627,7 @@ class EvaluationService:
         cases = [
             EvaluationCaseDefinition(
                 case_id=sample.id,
-                title=f"{sample.reviewer_name} 的反馈样本",
+                title=f"{sample.reviewer_name} ?????",
                 workflow_type=sample.workflow_type.value,
                 input_payload=sample.input_payload,
                 expected_status=sample.expected_status.value,
@@ -1544,8 +1637,8 @@ class EvaluationService:
         ]
         return EvaluationDatasetRuntime(
             dataset_id="feedback-loop-v1",
-            name="人工反馈闭环集",
-            description="由人工审核反馈自动构建的评测样本集。",
+            name="???????",
+            description="??????????????????",
             cases=cases,
         )
 
@@ -1646,7 +1739,7 @@ class BatchExperimentService:
             row["is_champion"] = index == 1
             row["champion_reason"] = ""
             if index == 1:
-                row["champion_reason"] = "综合得分最高，且成本与时延表现更优。"
+                row["champion_reason"] = "??????????????????"
                 champion = {
                     "variant_id": row["variant_id"],
                     "variant_label": row["variant_label"],
@@ -1697,20 +1790,20 @@ class CostAnalyticsService:
         projected_cost = round(total_cost / elapsed_days * days_in_month, 6) if total_cost else 0.0
 
         alert_level = "healthy"
-        alert_title = "预算运行正常"
-        alert_message = "当前模型消耗低于预警阈值，可以继续推进实验。"
+        alert_title = "??????"
+        alert_message = "??????????????????????"
         if spend_ratio >= 100:
             alert_level = "danger"
-            alert_title = "预算已超支"
-            alert_message = "当前月度模型成本已超过预算，请立即收敛高成本实验。"
+            alert_title = "?????"
+            alert_message = "?????????????????????????"
         elif spend_ratio >= 80:
             alert_level = "warning"
-            alert_title = "预算接近上限"
-            alert_message = "当前成本已超过 80% 预算，建议优先使用批量实验对比后再扩大运行。"
+            alert_title = "??????"
+            alert_message = "??????? 80% ??????????????????????"
         elif spend_ratio >= 50:
             alert_level = "notice"
-            alert_title = "预算进入观察区"
-            alert_message = "当前成本已超过 50% 预算，建议开始关注模型成本趋势。"
+            alert_title = "???????"
+            alert_message = "??????? 50% ????????????????"
 
         by_model: dict[str, dict[str, Any]] = {}
         for call in month_calls:
@@ -1758,8 +1851,8 @@ class CostAnalyticsService:
             "alert_title": alert_title,
             "alert_message": alert_message,
             "thresholds": [
-                {"label": "观察线", "ratio_percent": 50},
-                {"label": "预警线", "ratio_percent": 80},
-                {"label": "超支线", "ratio_percent": 100},
+                {"label": "???", "ratio_percent": 50},
+                {"label": "???", "ratio_percent": 80},
+                {"label": "???", "ratio_percent": 100},
             ],
         }

--- a/app/services.py
+++ b/app/services.py
@@ -503,18 +503,18 @@ class PlannerAgent:
         fallback = self._fallback_plan(request)
         planning_context, tool_call = self.planning_context_tool.run(request)
         system_prompt = (
-            "???? AI ????? PlannerAgent?"
-            "???????????????????????????????"
-            "???? JSON??? workflow_type?objective?steps?expected_outputs?"
-            "steps ??????????expected_outputs ????? agent ??????"
+            "你是企业 AI 工作流中的 PlannerAgent。"
+            "请结合任务输入、工作流模板和历史经验，输出一个结构化执行计划。"
+            "必须返回 JSON，键为 workflow_type、objective、steps、expected_outputs。"
+            "steps 需要可执行且有顺序，expected_outputs 需要与后续 agent 的产出一致。"
         )
         user_prompt = (
-            f"?? Prompt ???{prompt_profile.name} {prompt_profile.version}\n"
-            f"?????{prompt_profile.description}\n"
-            f"??????{request.workflow_type.value}\n"
-            f"???? JSON?\n{json.dumps(request.input_payload, ensure_ascii=False)}\n"
-            f"????????? JSON?\n{json.dumps(planning_context, ensure_ascii=False)}\n"
-            "????????????????????????????? objective ? steps ????"
+            f"当前 Prompt 方案：{prompt_profile.name} {prompt_profile.version}\n"
+            f"方案描述：{prompt_profile.description}\n"
+            f"工作流类型：{request.workflow_type.value}\n"
+            f"任务输入 JSON：\n{json.dumps(request.input_payload, ensure_ascii=False)}\n"
+            f"规划上下文工具结果 JSON：\n{json.dumps(planning_context, ensure_ascii=False)}\n"
+            "请生成适合当前任务的规划，若历史反馈里出现风险或缺口，请在 objective 或 steps 中体现。"
         )
         response = self.llm_service.generate_json(
             route_target="planner",
@@ -585,12 +585,12 @@ class PlannerAgent:
     @staticmethod
     def _objective(workflow_type: WorkflowType, payload: dict[str, Any]) -> str:
         if workflow_type == WorkflowType.SALES_FOLLOWUP:
-            return f"?? {payload.get('period', '????')} ? {payload.get('region', '????')} ?????"
+            return f"分析 {payload.get('period', '当前周期')} 在 {payload.get('region', '全部区域')} 的销售表现"
         if workflow_type == WorkflowType.MARKETING_CAMPAIGN:
-            return f"? {payload.get('product_name', '????')} ??????"
+            return f"为 {payload.get('product_name', '目标产品')} 生成投放内容"
         if workflow_type == WorkflowType.SUPPORT_TRIAGE:
-            return f"?? {len(payload.get('tickets', []))} ?????"
-        return f"? {payload.get('meeting_title', '??')} ????????"
+            return f"处理 {len(payload.get('tickets', []))} 条客服工单"
+        return f"将 {payload.get('meeting_title', '会议')} 纪要转成执行动作"
 
 
 class ToolCenter:
@@ -641,16 +641,16 @@ class ToolCenter:
         channels = payload.get("channels", ["xiaohongshu"])
         key_benefits = payload.get("key_benefits", [])
         return {
-            "product_name": payload.get("product_name", "????"),
-            "audience": payload.get("audience", "????"),
+            "product_name": payload.get("product_name", "目标产品"),
+            "audience": payload.get("audience", "目标人群"),
             "channels": channels,
             "key_benefits": key_benefits,
-            "tone": payload.get("tone", "????"),
+            "tone": payload.get("tone", "清晰直接"),
             "compliance_risks": [
-                "???????????",
-                "???????????",
+                "避免使用绝对化效果承诺",
+                "发布前复核产品能力表述",
             ],
-            "channel_notes": {channel: f"? {channel} ??????????????" for channel in channels},
+            "channel_notes": {channel: f"为 {channel} 准备一个主卖点和一个行动号召" for channel in channels},
         }
 
     def _support_triage(self, payload: dict[str, Any]) -> tuple[dict[str, Any], str]:
@@ -687,7 +687,7 @@ class ToolCenter:
             enriched.append(
                 {
                     "ticket_id": str(ticket.get("source_id") or f"T-{index:03d}"),
-                    "customer": ticket.get("customer", f"??{index}"),
+                    "customer": ticket.get("customer", f"客户{index}"),
                     "category": category,
                     "priority": severity,
                     "message": ticket.get("message", ""),
@@ -710,17 +710,17 @@ class ToolCenter:
         sentences = [item.strip(" .") for item in re.split(r"\d+\.\s*", notes) if item.strip()]
         actions = []
         for index, sentence in enumerate(sentences, start=1):
-            owner = sentence.split(" ", 1)[0] if sentence else f"???{index}"
+            owner = sentence.split(" ", 1)[0] if sentence else f"负责人{index}"
             actions.append(
                 {
                     "id": f"A-{index:03d}",
                     "owner": owner,
                     "task": sentence,
-                    "deadline": "?????",
+                    "deadline": "下个检查点",
                 }
             )
         return {
-            "meeting_title": payload.get("meeting_title", "??"),
+            "meeting_title": payload.get("meeting_title", "会议"),
             "action_items": actions,
             "owner_count": len({item["owner"] for item in actions}),
             "summary_points": sentences[:3],
@@ -742,13 +742,13 @@ class AnalystAgent:
     ) -> tuple[dict[str, Any], Any]:
         fallback = self._fallback_analysis(request.workflow_type, raw_result)
         system_prompt = (
-            "???? AI ????? AnalystAgent?????? JSON??? summary?insights?action_plan????????"
+            "你是企业 AI 工作流中的 AnalystAgent。请严格返回 JSON，键为 summary、insights、action_plan，全部使用中文。"
         )
         user_prompt = (
-            f"Prompt ?????{prompt_profile.analyst_instruction}\n"
-            f"??????{request.workflow_type.value}\n"
-            f"???? JSON?\n{json.dumps(raw_result, ensure_ascii=False)}\n"
-            f"???? JSON?\n{json.dumps(memory_context, ensure_ascii=False)}"
+            f"Prompt 方案要求：{prompt_profile.analyst_instruction}\n"
+            f"工作流类型：{request.workflow_type.value}\n"
+            f"原始结果 JSON：\n{json.dumps(raw_result, ensure_ascii=False)}\n"
+            f"历史记忆 JSON：\n{json.dumps(memory_context, ensure_ascii=False)}"
         )
         response = self.llm_service.generate_json(
             route_target="analyst",
@@ -767,53 +767,53 @@ class AnalystAgent:
     @staticmethod
     def _fallback_analysis(workflow_type: WorkflowType, raw_result: dict[str, Any]) -> dict[str, Any]:
         if workflow_type == WorkflowType.SALES_FOLLOWUP:
-            risk_names = "?".join(item["name"] for item in raw_result.get("risk_customers", [])) or "??"
+            risk_names = "、".join(item["name"] for item in raw_result.get("risk_customers", [])) or "暂无"
             return {
                 "summary": (
-                    f"?????? {raw_result.get('conversion_rate', 0):.0%}??????? {raw_result.get('avg_cycle_days', 0)} ??"
+                    f"当前转化率为 {raw_result.get('conversion_rate', 0):.0%}，平均销售周期 {raw_result.get('avg_cycle_days', 0)} 天。"
                 ),
                 "insights": [
-                    "????????????????????",
-                    f"?????????{risk_names}?",
+                    "整体转化表现偏弱，风险客户需要重点跟进。",
+                    f"当前风险客户包括：{risk_names}。",
                 ],
                 "action_plan": [
-                    "???????????????",
-                    "?????????????",
+                    "为风险客户制定一对一跟进计划。",
+                    "与区域负责人复盘停滞商机。",
                 ],
             }
         if workflow_type == WorkflowType.MARKETING_CAMPAIGN:
             return {
-                "summary": f"?? {raw_result.get('product_name', '??')} ?????????",
+                "summary": f"已为 {raw_result.get('product_name', '产品')} 准备投放内容方案。",
                 "insights": [
-                    "????????????????????",
-                    "????????????",
+                    "不同渠道需要统一卖点但单独设计行动号召。",
+                    "发布前需要复核合规表述。",
                 ],
                 "action_plan": [
-                    "???????????",
-                    "????????????",
+                    "为每个渠道明确主卖点。",
+                    "上线前增加一次合规检查。",
                 ],
             }
         if workflow_type == WorkflowType.SUPPORT_TRIAGE:
             return {
-                "summary": f"??? {raw_result.get('high_priority_count', 0)} ??????????????",
+                "summary": f"当前有 {raw_result.get('high_priority_count', 0)} 条高优先级工单需要优先处理。",
                 "insights": [
-                    "?????????????????",
-                    "??????????????????",
+                    "疑似故障类工单应优先进入人工接管。",
+                    "低风险账单类问题可自动生成回复草稿。",
                 ],
                 "action_plan": [
-                    "??????????????",
-                    "???????????????",
+                    "将故障工单升级给值班负责人。",
+                    "为低风险工单发送标准回复草稿。",
                 ],
             }
         return {
-            "summary": f"??? {len(raw_result.get('action_items', []))} ???????",
+            "summary": f"已抽取 {len(raw_result.get('action_items', []))} 条会议行动项。",
             "insights": [
-                "???????????????????",
-                "??????????????",
+                "每个行动项都需要明确责任人和检查节点。",
+                "简洁总结更利于团队快速执行。",
             ],
             "action_plan": [
-                "?????????????",
-                "????????????????",
+                "将行动项同步给对应负责人。",
+                "自动完成前复核截止时间是否清晰。",
             ],
         }
 
@@ -834,15 +834,15 @@ class ContentAgent:
     ) -> tuple[dict[str, Any], Any]:
         fallback = self._fallback_deliverables(request.workflow_type, raw_result, analysis)
         system_prompt = (
-            "???? AI ????? ContentAgent?????? JSON??? deliverables ? manager_note????????"
+            "你是企业 AI 工作流中的 ContentAgent。请严格返回 JSON，键为 deliverables 和 manager_note，全部使用中文。"
         )
         user_prompt = (
-            f"Prompt ?????{prompt_profile.content_instruction}\n"
-            f"??????{request.workflow_type.value}\n"
-            f"???? JSON?\n{json.dumps(raw_result, ensure_ascii=False)}\n"
-            f"???? JSON?\n{json.dumps(analysis, ensure_ascii=False)}"
+            f"Prompt 方案要求：{prompt_profile.content_instruction}\n"
+            f"工作流类型：{request.workflow_type.value}\n"
+            f"原始结果 JSON：\n{json.dumps(raw_result, ensure_ascii=False)}\n"
+            f"分析结果 JSON：\n{json.dumps(analysis, ensure_ascii=False)}"
         )
-        user_prompt += f"\n?????? JSON??n{json.dumps(memory_context, ensure_ascii=False)}"
+        user_prompt += f"\n鍘嗗彶璁板繂 JSON锛歕n{json.dumps(memory_context, ensure_ascii=False)}"
         response = self.llm_service.generate_json(
             route_target="content",
             system_prompt=system_prompt,
@@ -864,43 +864,43 @@ class ContentAgent:
     ) -> dict[str, Any]:
         if workflow_type == WorkflowType.SALES_FOLLOWUP:
             deliverables = {
-                "????": analysis.get("summary", ""),
+                "日报摘要": analysis.get("summary", ""),
                 "follow_up_plan": [
                     {
-                        "??": item["name"],
-                        "???": item["owner"],
-                        "?????": item["next_action"],
+                        "客户": item["name"],
+                        "负责人": item["owner"],
+                        "下一步动作": item["next_action"],
                     }
                     for item in raw_result.get("risk_customers", [])
                 ],
             }
-            manager_note = "????????????????????????????"
+            manager_note = "需要管理者确认风险客户跟进节奏和较长销售周期的处理策略。"
         elif workflow_type == WorkflowType.MARKETING_CAMPAIGN:
             deliverables = {
-                "??????": {
-                    channel: f"{raw_result.get('product_name', '??')} ?? {raw_result.get('audience', '????')} ? {channel} ????"
+                "渠道内容资产": {
+                    channel: f"{raw_result.get('product_name', '产品')} 面向 {raw_result.get('audience', '目标用户')} 的 {channel} 投放文案"
                     for channel in raw_result.get("channels", [])
                 },
-                "??????": raw_result.get("compliance_risks", []),
+                "发布检查清单": raw_result.get("compliance_risks", []),
             }
-            manager_note = "???????????????"
+            manager_note = "排期前建议先完成一次合规复核。"
         elif workflow_type == WorkflowType.SUPPORT_TRIAGE:
             deliverables = {
-                "????": [
+                "回复草稿": [
                     {
-                        "????": item["ticket_id"],
-                        "??": f"???????{item['category']}??????????????????",
+                        "工单编号": item["ticket_id"],
+                        "草稿": f"我们已收到关于{item['category']}的问题，正在为您进一步处理，请稍候。",
                     }
                     for item in raw_result.get("tickets", [])
                 ]
             }
-            manager_note = "??????????????????"
+            manager_note = "高优先级故障工单应由人工负责人复核。"
         else:
             deliverables = {
-                "??????": analysis.get("summary", ""),
-                "???": raw_result.get("action_items", []),
+                "会后摘要邮件": analysis.get("summary", ""),
+                "行动项": raw_result.get("action_items", []),
             }
-            manager_note = "?????????????????????"
+            manager_note = "建议将行动摘要同步给负责人并确认截止时间。"
         return {"deliverables": deliverables, "manager_note": manager_note}
 
 
@@ -921,15 +921,15 @@ class ReviewerAgent:
     ) -> tuple[dict[str, Any], Any]:
         fallback = self._rule_review(request.workflow_type, raw_result, analysis, deliverables)
         system_prompt = (
-            "???? AI ????? ReviewerAgent?????? JSON??? status?needs_human_review?score?reasons????????"
+            "你是企业 AI 工作流中的 ReviewerAgent。请严格返回 JSON，键为 status、needs_human_review、score、reasons，全部使用中文。"
         )
         user_prompt = (
-            f"Prompt ?????{prompt_profile.reviewer_instruction}\n"
-            f"??????{request.workflow_type.value}\n"
-            f"???? JSON?\n{json.dumps(raw_result, ensure_ascii=False)}\n"
-            f"???? JSON?\n{json.dumps(analysis, ensure_ascii=False)}\n"
-            f"???? JSON?\n{json.dumps(deliverables, ensure_ascii=False)}\n"
-            f"???? JSON?\n{json.dumps(memory_context, ensure_ascii=False)}"
+            f"Prompt 方案要求：{prompt_profile.reviewer_instruction}\n"
+            f"工作流类型：{request.workflow_type.value}\n"
+            f"原始结果 JSON：\n{json.dumps(raw_result, ensure_ascii=False)}\n"
+            f"分析结果 JSON：\n{json.dumps(analysis, ensure_ascii=False)}\n"
+            f"交付结果 JSON：\n{json.dumps(deliverables, ensure_ascii=False)}\n"
+            f"历史记忆 JSON：\n{json.dumps(memory_context, ensure_ascii=False)}"
         )
         response = self.llm_service.generate_json(
             route_target="reviewer",
@@ -955,31 +955,31 @@ class ReviewerAgent:
         if workflow_type == WorkflowType.SALES_FOLLOWUP:
             if raw_result.get("conversion_rate", 0) <= 0.15:
                 needs_human_review = True
-                reasons.append("????????????????????")
+                reasons.append("当前转化率偏低，跟进策略需要管理者确认。")
                 score = 0.65
             if raw_result.get("risk_customers"):
-                reasons.append("?????????????????")
+                reasons.append("风险客户需要明确负责人和跟进节奏。")
         elif workflow_type == WorkflowType.MARKETING_CAMPAIGN:
             needs_human_review = True
-            reasons.append("????????????????????")
+            reasons.append("营销内容需要人工复核品牌口径和合规表达。")
             score = 0.7
         elif workflow_type == WorkflowType.SUPPORT_TRIAGE:
             if raw_result.get("requires_incident_handoff"):
                 needs_human_review = True
-                reasons.append("????????????????")
+                reasons.append("疑似故障类工单必须进入人工接管。")
                 score = 0.6
         elif workflow_type == WorkflowType.MEETING_MINUTES:
             if not raw_result.get("action_items"):
                 needs_human_review = True
-                reasons.append("????????????????????")
+                reasons.append("当前未抽取到清晰的行动项，需要人工确认。")
                 score = 0.55
 
         if not reasons:
-            reasons.append("???????????????")
+            reasons.append("结果结构完整，可直接流转执行。")
         if not analysis or not deliverables:
             needs_human_review = True
             score = min(score, 0.5)
-            reasons.append("????????????????????")
+            reasons.append("核心分析或交付结果不完整，需要人工补充。")
         status = "waiting_human" if needs_human_review else "completed"
         return {
             "status": status,
@@ -1011,18 +1011,18 @@ class ReviewerAgent:
                 reason for reason in reasons
                 if not any(
                     text in reason.lower()
-                    for text in ["proceed automatically", "auto-complete", "can proceed directly", "????", "????"]
+                    for text in ["proceed automatically", "auto-complete", "can proceed directly", "直接流转", "自动流转"]
                 )
             ]
             if not reasons:
-                reasons = ["?????????????????"]
+                reasons = ["该任务需要人工审核后才能继续执行。"]
         else:
             reasons = [
                 reason for reason in reasons
                 if "human review" not in reason.lower() and "handoff" not in reason.lower()
             ]
             if not reasons:
-                reasons = ["???????????????????"]
+                reasons = ["结果完整且风险可控，可以直接自动流转。"]
 
         score = float(model_review.get("score", rule_review.get("score", 0.8)))
         if status == "waiting_human":
@@ -1124,22 +1124,22 @@ class FeedbackService:
                 seen.append(cleaned)
         if seen:
             return seen[:8]
-        return ["????", "????", "????"]
+        return ["人工审核", "质量复核", "执行清晰"]
 
     @staticmethod
     def _extract_quality_tags(run: WorkflowRun, comment: str) -> list[str]:
         tags = [run.workflow_type.value]
         text = f"{comment} {' '.join(run.review.reasons if run.review else [])}"
-        if "??" in text or "incident" in text.lower():
-            tags.append("????")
-        if "???" in text or "owner" in text.lower():
-            tags.append("????")
-        if "??" in text:
-            tags.append("????")
+        if "风险" in text or "incident" in text.lower():
+            tags.append("风险控制")
+        if "负责人" in text or "owner" in text.lower():
+            tags.append("责任清晰")
+        if "合规" in text:
+            tags.append("合规复核")
         if run.status == RunStatus.COMPLETED:
-            tags.append("???")
+            tags.append("可执行")
         else:
-            tags.append("?????")
+            tags.append("需人工判断")
         return tags
 
     @staticmethod
@@ -1149,7 +1149,7 @@ class FeedbackService:
             "completeness_weight": 35,
             "risk_control_weight": 30,
             "workflow_type": run.workflow_type.value,
-            "guide": "???????????????????????????????????",
+            "guide": "重点检查输出是否清晰、完整、可执行，并根据场景确认风险是否被正确识别。",
         }
 
 
@@ -1250,7 +1250,7 @@ class WorkflowEngine:
         )
         run.add_log(
             "HumanReviewer",
-            f"{reviewer_name}{'???' if submission.approve else '???'}???????{submission.comment or '?'}",
+            f"{reviewer_name}{'已通过' if submission.approve else '已驳回'}该任务。备注：{submission.comment or '无'}",
         )
         if run.review:
             run.review.status = run.status
@@ -1330,7 +1330,7 @@ class WorkflowEngine:
         state["planning_context"] = planning_context
         run.add_log(
             "PlannerAgent",
-            f"??????????? {len(plan.steps)} ????????????????",
+            f"已生成动态执行计划，共 {len(plan.steps)} 步，并注入规划上下文与历史记忆。",
             tool_call=tool_call,
             llm_call=llm_call,
         )
@@ -1342,7 +1342,7 @@ class WorkflowEngine:
         request = state["request"]
         run.touch(status=RunStatus.EXECUTING, current_step="operator")
         raw_result, tool_call = self.tool_center.run(request.workflow_type, request.input_payload)
-        run.add_log("OperatorAgent", f"????????{tool_call.name}?", tool_call=tool_call)
+        run.add_log("OperatorAgent", f"已完成工具调用：{tool_call.name}。", tool_call=tool_call)
         state["raw_result"] = raw_result
         state["last_node"] = "operator"
         return state
@@ -1368,7 +1368,7 @@ class WorkflowEngine:
         )
         run.add_log(
             "AnalystAgent",
-            f"?????????????????? {analyst_context['memory_hits']} ??????",
+            f"已完成结果分析与行动建议整理，并注入 {analyst_context['memory_hits']} 条历史记忆。",
             llm_call=llm_call,
         )
         state["analysis"] = analysis
@@ -1396,10 +1396,10 @@ class WorkflowEngine:
             execution_profile=state["execution_profile"],
             prompt_profile=state["prompt_profile"],
         )
-        run.add_log("ContentAgent", "??????????????", llm_call=llm_call)
+        run.add_log("ContentAgent", "已补充可直接使用的业务输出。", llm_call=llm_call)
         run.add_log(
             "ContentAgent",
-            f"??? {content_context['memory_hits']} ???????????????",
+            f"已注入 {content_context['memory_hits']} 条历史记忆，用于生成业务输出。",
         )
         state["deliverables"] = deliverables
         state["content_context"] = content_context
@@ -1444,7 +1444,7 @@ class WorkflowEngine:
         }
         run.add_log(
             "ReviewerAgent",
-            f"??????????? {reviewer_context['memory_hits']} ??????",
+            f"已完成审核判断，并注入 {reviewer_context['memory_hits']} 条历史记忆。",
             llm_call=llm_call,
         )
         state["review"] = review_payload
@@ -1463,7 +1463,7 @@ class WorkflowEngine:
         state["route_decisions"] = route_decisions
         run.add_log(
             "RouterAgent",
-            f"? {decision['from_node']} ??? {decision['next_node']}?{decision['reason']}",
+            f"从 {decision['from_node']} 路由到 {decision['next_node']}：{decision['reason']}",
         )
         return state
 
@@ -1477,7 +1477,7 @@ class WorkflowEngine:
         if run.review:
             run.review.status = RunStatus.COMPLETED
             run.review.needs_human_review = False
-        run.add_log("System", "?????????")
+        run.add_log("System", "工作流已自动完成。")
         run.result["route_decisions"] = state.get("route_decisions", [])
         run.result["metrics"] = summarize_run_metrics(run)
         return state
@@ -1488,7 +1488,7 @@ class WorkflowEngine:
         if run.review:
             run.review.status = RunStatus.WAITING_HUMAN
             run.review.needs_human_review = True
-        run.add_log("System", "???????????")
+        run.add_log("System", "工作流已进入人工审核。")
         run.result["route_decisions"] = state.get("route_decisions", [])
         run.result["metrics"] = summarize_run_metrics(run)
         return state
@@ -1506,8 +1506,8 @@ class EvaluationService:
             base.append(
                 {
                     "dataset_id": "feedback-loop-v1",
-                    "name": "???????",
-                    "description": "??????????????????",
+                    "name": "人工反馈闭环集",
+                    "description": "由人工审核结果自动沉淀生成的样本集。",
                     "case_count": str(len(samples)),
                 }
             )
@@ -1627,7 +1627,7 @@ class EvaluationService:
         cases = [
             EvaluationCaseDefinition(
                 case_id=sample.id,
-                title=f"{sample.reviewer_name} ?????",
+                title=f"{sample.reviewer_name} 的反馈样本",
                 workflow_type=sample.workflow_type.value,
                 input_payload=sample.input_payload,
                 expected_status=sample.expected_status.value,
@@ -1637,8 +1637,8 @@ class EvaluationService:
         ]
         return EvaluationDatasetRuntime(
             dataset_id="feedback-loop-v1",
-            name="???????",
-            description="??????????????????",
+            name="人工反馈闭环集",
+            description="由人工审核反馈自动构建的评测样本集。",
             cases=cases,
         )
 
@@ -1739,7 +1739,7 @@ class BatchExperimentService:
             row["is_champion"] = index == 1
             row["champion_reason"] = ""
             if index == 1:
-                row["champion_reason"] = "??????????????????"
+                row["champion_reason"] = "综合得分最高，且成本与时延表现更优。"
                 champion = {
                     "variant_id": row["variant_id"],
                     "variant_label": row["variant_label"],
@@ -1790,20 +1790,20 @@ class CostAnalyticsService:
         projected_cost = round(total_cost / elapsed_days * days_in_month, 6) if total_cost else 0.0
 
         alert_level = "healthy"
-        alert_title = "??????"
-        alert_message = "??????????????????????"
+        alert_title = "预算运行正常"
+        alert_message = "当前模型消耗低于预警阈值，可以继续推进实验。"
         if spend_ratio >= 100:
             alert_level = "danger"
-            alert_title = "?????"
-            alert_message = "?????????????????????????"
+            alert_title = "预算已超支"
+            alert_message = "当前月度模型成本已超过预算，请立即收敛高成本实验。"
         elif spend_ratio >= 80:
             alert_level = "warning"
-            alert_title = "??????"
-            alert_message = "??????? 80% ??????????????????????"
+            alert_title = "预算接近上限"
+            alert_message = "当前成本已超过 80% 预算，建议优先使用批量实验对比后再扩大运行。"
         elif spend_ratio >= 50:
             alert_level = "notice"
-            alert_title = "???????"
-            alert_message = "??????? 50% ????????????????"
+            alert_title = "预算进入观察区"
+            alert_message = "当前成本已超过 50% 预算，建议开始关注模型成本趋势。"
 
         by_model: dict[str, dict[str, Any]] = {}
         for call in month_calls:
@@ -1851,8 +1851,8 @@ class CostAnalyticsService:
             "alert_title": alert_title,
             "alert_message": alert_message,
             "thresholds": [
-                {"label": "???", "ratio_percent": 50},
-                {"label": "???", "ratio_percent": 80},
-                {"label": "???", "ratio_percent": 100},
+                {"label": "观察线", "ratio_percent": 50},
+                {"label": "预警线", "ratio_percent": 80},
+                {"label": "超支线", "ratio_percent": 100},
             ],
         }

--- a/docs/superpowers/plans/2026-04-15-dynamic-agent-router.md
+++ b/docs/superpowers/plans/2026-04-15-dynamic-agent-router.md
@@ -1,0 +1,109 @@
+# Dynamic Agent Router Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Convert the fixed linear LangGraph workflow into a state-driven router flow with one guarded replan loop.
+
+**Architecture:** Add a deterministic `RouterAgent` in `app/services.py` and route all major workflow nodes through it. Store route decisions in `WorkflowState` and final `run.result`, while preserving existing agent APIs and ToolCenter behavior.
+
+**Tech Stack:** Python, FastAPI, LangGraph, pytest
+
+---
+
+### Task 1: Lock graph metadata expectation
+
+**Files:**
+- Modify: `tests/test_workflows.py`
+- Modify: `app/services.py`
+
+- [ ] **Step 1: Write failing graph metadata assertions**
+
+```python
+def test_graph_endpoint_exposes_langgraph_shape() -> None:
+    login_as("viewer", "viewer123")
+    response = client.get("/api/workflows/graph")
+    body = response.json()
+    assert response.status_code == 200
+    assert body["runtime"] == "langgraph"
+    assert "router" in body["nodes"]
+    assert any(edge["from"] == "planner" and edge["to"] == "router" for edge in body["edges"])
+    assert any(edge["from"] == "router" and edge["to"] == "planner" for edge in body["edges"])
+```
+
+- [ ] **Step 2: Run failing test**
+
+Run: `python -m pytest tests/test_workflows.py -k graph_endpoint -q`
+Expected: FAIL because `router` is not yet exposed.
+
+### Task 2: Lock router behavior and persisted route trail
+
+**Files:**
+- Modify: `tests/test_workflows.py`
+- Modify: `app/services.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+def test_router_requests_one_replan_when_content_is_missing() -> None:
+    decision = RouterAgent().decide(
+        last_node="content",
+        state={"deliverables": {}, "replan_count": 0},
+    )
+    assert decision["next_node"] == "planner"
+    assert decision["replan_count"] == 1
+
+
+def test_workflow_result_records_route_decisions() -> None:
+    body = create_sales_run()
+    route_decisions = body["result"]["route_decisions"]
+    assert route_decisions[0]["from_node"] == "planner"
+    assert route_decisions[0]["next_node"] == "operator"
+    assert any(item["next_node"] == "reviewer" for item in route_decisions)
+```
+
+- [ ] **Step 2: Run failing tests**
+
+Run: `python -m pytest tests/test_workflows.py -k "router_requests_one_replan or workflow_result_records_route_decisions" -q`
+Expected: FAIL because `RouterAgent` and `route_decisions` do not exist yet.
+
+### Task 3: Implement router and graph rewiring
+
+**Files:**
+- Modify: `app/services.py`
+
+- [ ] **Step 1: Add state fields**
+
+Add `last_node`, `route_decisions`, `next_node`, and `replan_count` to `WorkflowState`.
+
+- [ ] **Step 2: Add `RouterAgent`**
+
+Add a deterministic router class with `decide(last_node, state)` returning a dict containing `from_node`, `next_node`, `reason`, and `replan_count`.
+
+- [ ] **Step 3: Rewire LangGraph**
+
+Add `router` as a graph node. Each major agent node goes to `router`; `router` conditionally routes to the next agent, terminal completion, or the guarded planner re-entry.
+
+- [ ] **Step 4: Persist route decisions**
+
+Include `route_decisions` in final `run.result` after review, and keep route logs visible through `RouterAgent` logs.
+
+### Task 4: Verify and publish
+
+**Files:**
+- Test: `tests/test_workflows.py`
+
+- [ ] **Step 1: Run targeted tests**
+
+Run: `python -m pytest tests/test_workflows.py -k "graph_endpoint or router_requests_one_replan or workflow_result_records_route_decisions" -q`
+Expected: PASS
+
+- [ ] **Step 2: Run full suite**
+
+Run: `python -m pytest -q`
+Expected: PASS
+
+- [ ] **Step 3: Commit and PR**
+
+Commit: `feat: add dynamic agent router`
+Open a draft PR against `main` and comment on issue #4 in Chinese with scope and validation.
+

--- a/docs/superpowers/specs/2026-04-15-dynamic-agent-router-design.md
+++ b/docs/superpowers/specs/2026-04-15-dynamic-agent-router-design.md
@@ -1,0 +1,40 @@
+# Dynamic Agent Router Design
+
+## Goal
+
+Make the workflow behave like a state-driven multi-agent system instead of a fixed linear chain. Phase 1 keeps the current agent set and tool layer, but inserts a router that chooses the next agent from current state and can send execution back to Planner once when the plan needs revision.
+
+## Scope
+
+- Preserve existing agents: `PlannerAgent`, `OperatorAgent`, `AnalystAgent`, `ContentAgent`, `ReviewerAgent`.
+- Add a `RouterAgent` that decides the next node after each major step.
+- Replace fixed linear graph edges with router-mediated conditional edges.
+- Track route decisions in workflow state and final `run.result`.
+- Allow at most one `planner` re-entry to avoid infinite loops.
+- Keep `ToolCenter` dispatch unchanged; issue #2 can handle model-driven tool calling later.
+
+## Routing Rules
+
+The router is deterministic in this phase so tests and disabled-LLM mode stay stable:
+
+- After `planner`, route to `operator`.
+- After `operator`, route to `analyst` when raw data exists.
+- After `analyst`, route to `content` when analysis exists.
+- After `content`, route to `planner` once if deliverables are empty or missing; otherwise route to `reviewer`.
+- After `reviewer`, route to `handoff_run` when review status is `waiting_human`; otherwise route to `complete_run`.
+
+Each decision records `from_node`, `next_node`, `reason`, and `replan_count`.
+
+## Non-Goals
+
+- No dynamically registered agents.
+- No LLM-driven router in this phase.
+- No tool calling protocol refactor.
+- No UI redesign beyond graph metadata already exposed by `/api/workflows/graph`.
+
+## Test Strategy
+
+- Assert graph metadata exposes the router node and conditional route edges.
+- Unit-test the router replan decision when content deliverables are missing.
+- Add workflow-level coverage that route decisions are persisted in `run.result`.
+

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -5,7 +5,7 @@ from fastapi.testclient import TestClient
 from app.config import Settings
 from app.db import UserAccountRecord
 from app.main import app, database
-from app.services import ReviewerAgent
+from app.services import ReviewerAgent, RouterAgent
 
 
 client = TestClient(app)
@@ -28,8 +28,8 @@ def create_sales_run() -> dict:
             "workflow_type": "sales_followup",
             "input_payload": {
                 "period": "2026-W13",
-                "region": "华东",
-                "sales_reps": ["王晨", "李雪"],
+                "region": "??",
+                "sales_reps": ["??", "??"],
                 "focus_metric": "conversion_rate",
             },
             "model_name_override": "qwen-plus",
@@ -50,8 +50,8 @@ def create_support_run() -> dict:
             "input_payload": {
                 "tickets": [
                     {
-                        "customer": "示例客户",
-                        "message": "生产接口持续报错，今天必须恢复，否则影响上线。",
+                        "customer": "????",
+                        "message": "???????????????????????",
                     }
                 ]
             },
@@ -95,8 +95,8 @@ def test_dashboard_renders_all_real_data_source_options() -> None:
     login_as("operator", "operator123")
     response = client.get("/dashboard")
     assert response.status_code == 200
-    assert "新建工作流" in response.text
-    assert "真实数据源配置" in response.text
+    assert "?????" in response.text
+    assert "???????" in response.text
     assert "GitHub Issues" in response.text
     assert "NYC 311" in response.text
     assert "Stack Overflow" in response.text
@@ -130,8 +130,10 @@ def test_graph_endpoint_exposes_langgraph_shape() -> None:
     body = response.json()
     assert response.status_code == 200
     assert body["runtime"] == "langgraph"
-    assert "planner" in body["nodes"]
-    assert any(edge["from"] == "reviewer" for edge in body["edges"])
+    assert "router" in body["nodes"]
+    assert any(edge["from"] == "planner" and edge["to"] == "router" for edge in body["edges"])
+    assert any(edge["from"] == "router" and edge["to"] == "planner" for edge in body["edges"])
+    assert any(edge["from"] == "router" and edge["to"] == "reviewer" for edge in body["edges"])
 
 
 def test_review_page_requires_reviewer_role() -> None:
@@ -160,25 +162,45 @@ def test_sales_workflow_runs_with_selected_model_prompt_and_routing() -> None:
     assert {log["llm_call"]["route_target"] for log in llm_logs} == {"planner", "analyst", "content", "reviewer"}
 
 
+def test_router_requests_one_replan_when_content_is_missing() -> None:
+    decision = RouterAgent().decide(
+        last_node="content",
+        state={"deliverables": {}, "replan_count": 0},
+    )
+
+    assert decision["next_node"] == "planner"
+    assert decision["replan_count"] == 1
+
+
+def test_workflow_result_records_route_decisions() -> None:
+    body = create_sales_run()
+
+    route_decisions = body["result"]["route_decisions"]
+
+    assert route_decisions[0]["from_node"] == "planner"
+    assert route_decisions[0]["next_node"] == "operator"
+    assert any(item["next_node"] == "reviewer" for item in route_decisions)
+
+
 def test_waiting_human_reasons_do_not_include_auto_execute_copy() -> None:
     merged = ReviewerAgent._merge_review(
         {
             "status": "completed",
             "needs_human_review": False,
             "score": 0.92,
-            "reasons": ["结果结构完整，可直接流转执行。"],
+            "reasons": ["???????????????"],
         },
         {
             "status": "waiting_human",
             "needs_human_review": True,
             "score": 0.65,
-            "reasons": ["跟进策略需要管理者确认后才能执行。"],
+            "reasons": ["?????????????????"],
         },
     )
     assert merged["status"] == "waiting_human"
     assert merged["needs_human_review"] is True
-    assert all("直接流转" not in reason for reason in merged["reasons"])
-    assert any("确认" in reason or "审核" in reason for reason in merged["reasons"])
+    assert all("????" not in reason for reason in merged["reasons"])
+    assert any("??" in reason or "??" in reason for reason in merged["reasons"])
 
 
 def test_support_workflow_flags_human_review_and_can_be_approved() -> None:
@@ -192,20 +214,20 @@ def test_support_workflow_flags_human_review_and_can_be_approved() -> None:
 
     approved = client.post(
         f"/api/workflows/{body['id']}/review",
-        json={"approve": True, "comment": "值班负责人已确认回复策略与处理方案。"},
+        json={"approve": True, "comment": "??????????????????"},
     ).json()
     assert approved["status"] == "completed"
-    assert any("已通过" in log["message"] for log in approved["logs"])
+    assert any("???" in log["message"] for log in approved["logs"])
 
 
 def test_run_detail_page_contains_all_export_formats() -> None:
     created = create_sales_run()
     detail = client.get(f"/runs/{created['id']}")
     assert detail.status_code == 200
-    assert "执行时间线" in detail.text
-    assert "导出 Markdown" in detail.text
-    assert "导出 HTML" in detail.text
-    assert "导出 PDF" in detail.text
+    assert "?????" in detail.text
+    assert "?? Markdown" in detail.text
+    assert "?? HTML" in detail.text
+    assert "?? PDF" in detail.text
 
 
 def test_workflow_export_endpoint_supports_markdown_html_and_pdf() -> None:
@@ -225,8 +247,8 @@ def test_runs_page_supports_status_and_workflow_filters() -> None:
     create_support_run()
     response = client.get("/runs?status_filter=waiting_human&workflow_filter=support_triage")
     assert response.status_code == 200
-    assert "只看待审核" in response.text
-    assert "客服工单智能分流" in response.text
+    assert "?????" in response.text
+    assert "????????" in response.text
 
 
 def test_prompt_profile_can_be_created_and_updated() -> None:
@@ -237,12 +259,12 @@ def test_prompt_profile_can_be_created_and_updated() -> None:
         json={
             "profile_id": profile_id,
             "base_profile_id": "ops-deep-v1",
-            "name": "运营实验版",
+            "name": "?????",
             "version": "v1",
-            "description": "用于评估更强运营语言风格的实验方案。",
-            "analyst_instruction": "更强调根因分析。",
-            "content_instruction": "更强调责任人与截止时间。",
-            "reviewer_instruction": "风险不清晰时更偏向人工审核。",
+            "description": "??????????????????",
+            "analyst_instruction": "????????",
+            "content_instruction": "????????????",
+            "reviewer_instruction": "??????????????",
         },
     )
     assert created.status_code == 200
@@ -253,12 +275,12 @@ def test_prompt_profile_can_be_created_and_updated() -> None:
         json={
             "profile_id": profile_id,
             "base_profile_id": "ops-deep-v1",
-            "name": "运营实验版",
+            "name": "?????",
             "version": "v2",
-            "description": "用于评估更强运营语言风格的实验方案。",
-            "analyst_instruction": "更强调根因分析和优先级。",
-            "content_instruction": "更强调责任人与截止时间。",
-            "reviewer_instruction": "风险不清晰时更偏向人工审核。",
+            "description": "??????????????????",
+            "analyst_instruction": "????????????",
+            "content_instruction": "????????????",
+            "reviewer_instruction": "??????????????",
         },
     )
     assert updated.status_code == 200
@@ -282,7 +304,7 @@ def test_evaluation_run_page_supports_trend_and_drilldown_and_exports() -> None:
     login_as("operator", "operator123")
     page = client.get("/evaluations")
     assert page.status_code == 200
-    assert "自动评测" in page.text
+    assert "????" in page.text
 
     response = client.post(
         "/evaluations/run",
@@ -298,8 +320,8 @@ def test_evaluation_run_page_supports_trend_and_drilldown_and_exports() -> None:
         follow_redirects=True,
     )
     assert response.status_code == 200
-    assert "评测趋势" in response.text
-    assert "查看单案例明细" in response.text
+    assert "????" in response.text
+    assert "???????" in response.text
 
     evaluations = client.get("/api/evaluations").json()
     assert len(evaluations) >= 1
@@ -317,26 +339,26 @@ def test_batch_experiment_run_and_listing_work() -> None:
     response = client.post(
         "/api/batches",
         json={
-            "name": "Prompt AB 回归",
+            "name": "Prompt AB ??",
             "workflow_type": "sales_followup",
             "input_payload": {
                 "period": "2026-W13",
-                "region": "华东",
-                "sales_reps": ["王晨", "李雪"],
+                "region": "??",
+                "sales_reps": ["??", "??"],
                 "focus_metric": "conversion_rate",
             },
             "repeats": 1,
             "variants": [
                 {
                     "variant_id": "control",
-                    "label": "对照组",
+                    "label": "???",
                     "model_name": "qwen-plus",
                     "prompt_profile_id": "balanced-v1",
                     "routing_policy_id": "balanced-router-v1",
                 },
                 {
                     "variant_id": "challenger",
-                    "label": "挑战组",
+                    "label": "???",
                     "model_name": "qwen3-max",
                     "prompt_profile_id": "ops-deep-v1",
                     "routing_policy_id": "strict-review-v1",
@@ -355,7 +377,7 @@ def test_feedback_review_creates_feedback_sample() -> None:
     login_as("reviewer", "reviewer123")
     client.post(
         f"/api/workflows/{body['id']}/review",
-        json={"approve": True, "comment": "需要保留负责人和风险说明。"},
+        json={"approve": True, "comment": "?????????????"},
     )
     feedback_samples = client.get("/api/feedback-samples")
     assert feedback_samples.status_code == 200
@@ -380,8 +402,8 @@ def test_runtime_memory_context_is_recorded_for_analyst_and_reviewer() -> None:
     assert reviewer_context["memory_hits"] >= 1
     assert len(analyst_context["memory"]["recent_runs"]) >= 1
     assert len(reviewer_context["memory"]["feedback_samples"]) >= 1
-    assert any("历史记忆" in log["message"] for log in second["logs"] if log["agent"] == "AnalystAgent")
-    assert any("历史记忆" in log["message"] for log in second["logs"] if log["agent"] == "ReviewerAgent")
+    assert any("????" in log["message"] for log in second["logs"] if log["agent"] == "AnalystAgent")
+    assert any("????" in log["message"] for log in second["logs"] if log["agent"] == "ReviewerAgent")
 
 
 def test_runtime_memory_context_is_recorded_for_content_agent() -> None:
@@ -400,7 +422,7 @@ def test_runtime_memory_context_is_recorded_for_content_agent() -> None:
     assert content_context["memory_hits"] >= 1
     assert len(content_context["memory"]["recent_runs"]) >= 1
     assert len(content_context["memory"]["feedback_samples"]) >= 1
-    assert any("历史记忆" in log["message"] for log in second["logs"] if log["agent"] == "ContentAgent")
+    assert any("????" in log["message"] for log in second["logs"] if log["agent"] == "ContentAgent")
 
 
 def test_run_detail_page_shows_runtime_memory_summary() -> None:
@@ -417,7 +439,7 @@ def test_run_detail_page_shows_runtime_memory_summary() -> None:
     detail = client.get(f"/runs/{second['id']}")
 
     assert detail.status_code == 200
-    assert "运行时记忆" in detail.text
+    assert "?????" in detail.text
     assert "AnalystAgent" in detail.text
     assert "ContentAgent" in detail.text
     assert "ReviewerAgent" in detail.text

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -28,8 +28,8 @@ def create_sales_run() -> dict:
             "workflow_type": "sales_followup",
             "input_payload": {
                 "period": "2026-W13",
-                "region": "??",
-                "sales_reps": ["??", "??"],
+                "region": "华东",
+                "sales_reps": ["王晨", "李雪"],
                 "focus_metric": "conversion_rate",
             },
             "model_name_override": "qwen-plus",
@@ -50,8 +50,8 @@ def create_support_run() -> dict:
             "input_payload": {
                 "tickets": [
                     {
-                        "customer": "????",
-                        "message": "???????????????????????",
+                        "customer": "示例客户",
+                        "message": "生产接口持续报错，今天必须恢复，否则影响上线。",
                     }
                 ]
             },
@@ -95,8 +95,8 @@ def test_dashboard_renders_all_real_data_source_options() -> None:
     login_as("operator", "operator123")
     response = client.get("/dashboard")
     assert response.status_code == 200
-    assert "?????" in response.text
-    assert "???????" in response.text
+    assert "新建工作流" in response.text
+    assert "真实数据源配置" in response.text
     assert "GitHub Issues" in response.text
     assert "NYC 311" in response.text
     assert "Stack Overflow" in response.text
@@ -188,19 +188,19 @@ def test_waiting_human_reasons_do_not_include_auto_execute_copy() -> None:
             "status": "completed",
             "needs_human_review": False,
             "score": 0.92,
-            "reasons": ["???????????????"],
+            "reasons": ["结果结构完整，可直接流转执行。"],
         },
         {
             "status": "waiting_human",
             "needs_human_review": True,
             "score": 0.65,
-            "reasons": ["?????????????????"],
+            "reasons": ["跟进策略需要管理者确认后才能执行。"],
         },
     )
     assert merged["status"] == "waiting_human"
     assert merged["needs_human_review"] is True
-    assert all("????" not in reason for reason in merged["reasons"])
-    assert any("??" in reason or "??" in reason for reason in merged["reasons"])
+    assert all("直接流转" not in reason for reason in merged["reasons"])
+    assert any("确认" in reason or "审核" in reason for reason in merged["reasons"])
 
 
 def test_support_workflow_flags_human_review_and_can_be_approved() -> None:
@@ -214,20 +214,20 @@ def test_support_workflow_flags_human_review_and_can_be_approved() -> None:
 
     approved = client.post(
         f"/api/workflows/{body['id']}/review",
-        json={"approve": True, "comment": "??????????????????"},
+        json={"approve": True, "comment": "值班负责人已确认回复策略与处理方案。"},
     ).json()
     assert approved["status"] == "completed"
-    assert any("???" in log["message"] for log in approved["logs"])
+    assert any("已通过" in log["message"] for log in approved["logs"])
 
 
 def test_run_detail_page_contains_all_export_formats() -> None:
     created = create_sales_run()
     detail = client.get(f"/runs/{created['id']}")
     assert detail.status_code == 200
-    assert "?????" in detail.text
-    assert "?? Markdown" in detail.text
-    assert "?? HTML" in detail.text
-    assert "?? PDF" in detail.text
+    assert "执行时间线" in detail.text
+    assert "导出 Markdown" in detail.text
+    assert "导出 HTML" in detail.text
+    assert "导出 PDF" in detail.text
 
 
 def test_workflow_export_endpoint_supports_markdown_html_and_pdf() -> None:
@@ -247,8 +247,8 @@ def test_runs_page_supports_status_and_workflow_filters() -> None:
     create_support_run()
     response = client.get("/runs?status_filter=waiting_human&workflow_filter=support_triage")
     assert response.status_code == 200
-    assert "?????" in response.text
-    assert "????????" in response.text
+    assert "只看待审核" in response.text
+    assert "客服工单智能分流" in response.text
 
 
 def test_prompt_profile_can_be_created_and_updated() -> None:
@@ -259,12 +259,12 @@ def test_prompt_profile_can_be_created_and_updated() -> None:
         json={
             "profile_id": profile_id,
             "base_profile_id": "ops-deep-v1",
-            "name": "?????",
+            "name": "运营实验版",
             "version": "v1",
-            "description": "??????????????????",
-            "analyst_instruction": "????????",
-            "content_instruction": "????????????",
-            "reviewer_instruction": "??????????????",
+            "description": "用于评估更强运营语言风格的实验方案。",
+            "analyst_instruction": "更强调根因分析。",
+            "content_instruction": "更强调责任人与截止时间。",
+            "reviewer_instruction": "风险不清晰时更偏向人工审核。",
         },
     )
     assert created.status_code == 200
@@ -275,12 +275,12 @@ def test_prompt_profile_can_be_created_and_updated() -> None:
         json={
             "profile_id": profile_id,
             "base_profile_id": "ops-deep-v1",
-            "name": "?????",
+            "name": "运营实验版",
             "version": "v2",
-            "description": "??????????????????",
-            "analyst_instruction": "????????????",
-            "content_instruction": "????????????",
-            "reviewer_instruction": "??????????????",
+            "description": "用于评估更强运营语言风格的实验方案。",
+            "analyst_instruction": "更强调根因分析和优先级。",
+            "content_instruction": "更强调责任人与截止时间。",
+            "reviewer_instruction": "风险不清晰时更偏向人工审核。",
         },
     )
     assert updated.status_code == 200
@@ -304,7 +304,7 @@ def test_evaluation_run_page_supports_trend_and_drilldown_and_exports() -> None:
     login_as("operator", "operator123")
     page = client.get("/evaluations")
     assert page.status_code == 200
-    assert "????" in page.text
+    assert "自动评测" in page.text
 
     response = client.post(
         "/evaluations/run",
@@ -320,8 +320,8 @@ def test_evaluation_run_page_supports_trend_and_drilldown_and_exports() -> None:
         follow_redirects=True,
     )
     assert response.status_code == 200
-    assert "????" in response.text
-    assert "???????" in response.text
+    assert "评测趋势" in response.text
+    assert "查看单案例明细" in response.text
 
     evaluations = client.get("/api/evaluations").json()
     assert len(evaluations) >= 1
@@ -339,26 +339,26 @@ def test_batch_experiment_run_and_listing_work() -> None:
     response = client.post(
         "/api/batches",
         json={
-            "name": "Prompt AB ??",
+            "name": "Prompt AB 回归",
             "workflow_type": "sales_followup",
             "input_payload": {
                 "period": "2026-W13",
-                "region": "??",
-                "sales_reps": ["??", "??"],
+                "region": "华东",
+                "sales_reps": ["王晨", "李雪"],
                 "focus_metric": "conversion_rate",
             },
             "repeats": 1,
             "variants": [
                 {
                     "variant_id": "control",
-                    "label": "???",
+                    "label": "对照组",
                     "model_name": "qwen-plus",
                     "prompt_profile_id": "balanced-v1",
                     "routing_policy_id": "balanced-router-v1",
                 },
                 {
                     "variant_id": "challenger",
-                    "label": "???",
+                    "label": "挑战组",
                     "model_name": "qwen3-max",
                     "prompt_profile_id": "ops-deep-v1",
                     "routing_policy_id": "strict-review-v1",
@@ -377,7 +377,7 @@ def test_feedback_review_creates_feedback_sample() -> None:
     login_as("reviewer", "reviewer123")
     client.post(
         f"/api/workflows/{body['id']}/review",
-        json={"approve": True, "comment": "?????????????"},
+        json={"approve": True, "comment": "需要保留负责人和风险说明。"},
     )
     feedback_samples = client.get("/api/feedback-samples")
     assert feedback_samples.status_code == 200
@@ -402,8 +402,8 @@ def test_runtime_memory_context_is_recorded_for_analyst_and_reviewer() -> None:
     assert reviewer_context["memory_hits"] >= 1
     assert len(analyst_context["memory"]["recent_runs"]) >= 1
     assert len(reviewer_context["memory"]["feedback_samples"]) >= 1
-    assert any("????" in log["message"] for log in second["logs"] if log["agent"] == "AnalystAgent")
-    assert any("????" in log["message"] for log in second["logs"] if log["agent"] == "ReviewerAgent")
+    assert any("历史记忆" in log["message"] for log in second["logs"] if log["agent"] == "AnalystAgent")
+    assert any("历史记忆" in log["message"] for log in second["logs"] if log["agent"] == "ReviewerAgent")
 
 
 def test_runtime_memory_context_is_recorded_for_content_agent() -> None:
@@ -422,7 +422,7 @@ def test_runtime_memory_context_is_recorded_for_content_agent() -> None:
     assert content_context["memory_hits"] >= 1
     assert len(content_context["memory"]["recent_runs"]) >= 1
     assert len(content_context["memory"]["feedback_samples"]) >= 1
-    assert any("????" in log["message"] for log in second["logs"] if log["agent"] == "ContentAgent")
+    assert any("历史记忆" in log["message"] for log in second["logs"] if log["agent"] == "ContentAgent")
 
 
 def test_run_detail_page_shows_runtime_memory_summary() -> None:
@@ -439,7 +439,7 @@ def test_run_detail_page_shows_runtime_memory_summary() -> None:
     detail = client.get(f"/runs/{second['id']}")
 
     assert detail.status_code == 200
-    assert "?????" in detail.text
+    assert "运行时记忆" in detail.text
     assert "AnalystAgent" in detail.text
     assert "ContentAgent" in detail.text
     assert "ReviewerAgent" in detail.text


### PR DESCRIPTION
﻿## Summary
- add a deterministic RouterAgent that routes between existing workflow agents based on workflow state
- rewire LangGraph from fixed linear edges into router-mediated conditional routing, including one guarded replan path back to PlannerAgent
- persist route_decisions in run results and expose router edges through the workflow graph API
- document the phase-1 design and implementation plan for issue #4

## Scope
This is issue #4 phase 1. It keeps the existing agent set and ToolCenter unchanged. Dynamic agent registration and model-driven tool calling remain out of scope for this PR.

## Test Plan
- python -m pytest tests/test_workflows.py -k "graph_endpoint or router_requests_one_replan or workflow_result_records_route_decisions" -q
- python -m pytest tests/test_workflows.py -k "workflow or graph_endpoint or router" -q
- python -m pytest -q

Refs #4
