### PR TITLE
[codex] add llm router fallback

### DIFF
--- a/app/services.py
+++ b/app/services.py
@@ -9,6 +9,7 @@ from statistics import mean
 from typing import Any, TypedDict
 
 from langgraph.graph import END, START, StateGraph
+from pydantic import BaseModel, Field, ValidationError
 
 from app.config import Settings
 from app.data import RISK_CUSTOMERS, SALES_DATA, WORKFLOW_TEMPLATES
@@ -1035,8 +1036,42 @@ class ReviewerAgent:
         }
 
 
+class RouterDecision(BaseModel):
+    route: str
+    reason: str
+    confidence: float = Field(ge=0.0, le=1.0)
+    fallback_required: bool = False
+
+
 class RouterAgent:
+    ALLOWED_ROUTES = {"planner", "operator", "analyst", "content", "reviewer", "complete_run", "handoff_run"}
+    MIN_CONFIDENCE = 0.7
+
+    def __init__(self, llm_service: LLMService | None = None) -> None:
+        self.llm_service = llm_service
+
     def decide(self, *, last_node: str, state: dict[str, Any]) -> dict[str, Any]:
+        rule_decision = self._rule_decision(last_node=last_node, state=state)
+        model_decision, fallback_reason = self._model_decision(
+            last_node=last_node,
+            state=state,
+            rule_decision=rule_decision,
+        )
+        if model_decision is not None and fallback_reason is None:
+            return self._build_audit_decision(
+                rule_decision=rule_decision,
+                model_decision=model_decision,
+                used_fallback=False,
+                fallback_reason=None,
+            )
+        return self._build_audit_decision(
+            rule_decision=rule_decision,
+            model_decision=model_decision,
+            used_fallback=True,
+            fallback_reason=fallback_reason or "llm_unavailable",
+        )
+
+    def _rule_decision(self, *, last_node: str, state: dict[str, Any]) -> dict[str, Any]:
         replan_count = int(state.get("replan_count", 0) or 0)
         next_node = "complete_run"
         reason = "workflow state is complete"
@@ -1073,6 +1108,106 @@ class RouterAgent:
             "next_node": next_node,
             "reason": reason,
             "replan_count": replan_count,
+        }
+
+    def _model_decision(
+        self,
+        *,
+        last_node: str,
+        state: dict[str, Any],
+        rule_decision: dict[str, Any],
+    ) -> tuple[RouterDecision | None, str | None]:
+        if self.llm_service is None or state.get("execution_profile") is None:
+            return None, "llm_unavailable"
+        fallback_payload = {
+            "route": rule_decision["next_node"],
+            "reason": rule_decision["reason"],
+            "confidence": 0.0,
+            "fallback_required": True,
+        }
+        try:
+            response = self.llm_service.generate_json(
+                route_target="router",
+                system_prompt=(
+                    "你是企业 AI 工作流中的 RouterAgent。"
+                    "请只返回 JSON，字段为 route、reason、confidence、fallback_required。"
+                    "route 只能从 planner、operator、analyst、content、reviewer、complete_run、handoff_run 中选择。"
+                    "如果信息不足或不确定，请设置 fallback_required=true。"
+                ),
+                user_prompt=json.dumps(self._router_context(last_node, state, rule_decision), ensure_ascii=False),
+                fallback=fallback_payload,
+                execution_profile=state["execution_profile"],
+                response_model=RouterDecision,
+            )
+        except Exception:
+            return None, "model_error"
+
+        call = getattr(response, "call", None)
+        if bool(getattr(call, "used_fallback", False)):
+            return None, str(getattr(call, "error", None) or getattr(call, "validation_error", None) or "model_fallback")
+
+        try:
+            model_decision = RouterDecision.model_validate(response.payload)
+        except ValidationError:
+            return None, "schema_validation_failed"
+
+        if model_decision.route not in self.ALLOWED_ROUTES:
+            return model_decision, "route_not_allowed"
+        if model_decision.confidence < self.MIN_CONFIDENCE:
+            return model_decision, "low_confidence"
+        if model_decision.fallback_required:
+            return model_decision, "fallback_required"
+        if model_decision.route == "planner" and int(state.get("replan_count", 0) or 0) >= 1:
+            return model_decision, "replan_limit_reached"
+        return model_decision, None
+
+    def _build_audit_decision(
+        self,
+        *,
+        rule_decision: dict[str, Any],
+        model_decision: RouterDecision | None,
+        used_fallback: bool,
+        fallback_reason: str | None,
+    ) -> dict[str, Any]:
+        model_route = model_decision.route if model_decision is not None else None
+        confidence = model_decision.confidence if model_decision is not None else None
+        final_route = rule_decision["next_node"] if used_fallback else model_decision.route
+        reason = rule_decision["reason"] if used_fallback else model_decision.reason
+        replan_count = int(rule_decision["replan_count"])
+        if not used_fallback and final_route == "planner":
+            replan_count += 1
+        return {
+            "from_node": rule_decision["from_node"],
+            "next_node": final_route,
+            "route": final_route,
+            "model_route": model_route,
+            "final_route": final_route,
+            "decision_source": "rule" if used_fallback else "model",
+            "confidence": confidence,
+            "used_fallback": used_fallback,
+            "fallback_reason": fallback_reason,
+            "reason": reason,
+            "replan_count": replan_count,
+        }
+
+    @staticmethod
+    def _router_context(last_node: str, state: dict[str, Any], rule_decision: dict[str, Any]) -> dict[str, Any]:
+        request = state.get("request")
+        workflow_type = getattr(getattr(request, "workflow_type", None), "value", None)
+        review = state.get("review", {})
+        deliverables = state.get("deliverables", {})
+        nested_deliverables = deliverables.get("deliverables", {}) if isinstance(deliverables, dict) else {}
+        return {
+            "last_node": last_node,
+            "workflow_type": workflow_type,
+            "replan_count": int(state.get("replan_count", 0) or 0),
+            "has_raw_result": bool(state.get("raw_result")),
+            "has_analysis": bool(state.get("analysis")),
+            "has_deliverables": not RouterAgent._missing_deliverables(deliverables),
+            "deliverable_keys": list(nested_deliverables.keys()) if isinstance(nested_deliverables, dict) else [],
+            "review_status": review.get("status") if isinstance(review, dict) else None,
+            "rule_route": rule_decision["next_node"],
+            "allowed_routes": sorted(RouterAgent.ALLOWED_ROUTES),
         }
 
     @staticmethod
@@ -1167,7 +1302,7 @@ class WorkflowEngine:
         self.analyst_agent = AnalystAgent(self.llm_service)
         self.content_agent = ContentAgent(self.llm_service)
         self.reviewer_agent = ReviewerAgent(self.llm_service)
-        self.router_agent = RouterAgent()
+        self.router_agent = RouterAgent(self.llm_service)
         self.feedback_service = FeedbackService(repository)
         self.graph = self._build_graph()
 

--- a/app/services.py
+++ b/app/services.py
@@ -1157,6 +1157,8 @@ class RouterAgent:
             return model_decision, "low_confidence"
         if model_decision.fallback_required:
             return model_decision, "fallback_required"
+        if not self._route_is_state_ready(model_decision.route, state):
+            return model_decision, "route_not_ready"
         if model_decision.route == "planner" and int(state.get("replan_count", 0) or 0) >= 1:
             return model_decision, "replan_limit_reached"
         return model_decision, None
@@ -1209,6 +1211,25 @@ class RouterAgent:
             "rule_route": rule_decision["next_node"],
             "allowed_routes": sorted(RouterAgent.ALLOWED_ROUTES),
         }
+
+    @staticmethod
+    def _route_is_state_ready(route: str, state: dict[str, Any]) -> bool:
+        if route in {"planner", "operator"}:
+            return True
+        if route == "analyst":
+            return bool(state.get("raw_result"))
+        if route == "content":
+            return bool(state.get("raw_result")) and bool(state.get("analysis"))
+        if route == "reviewer":
+            return (
+                bool(state.get("raw_result"))
+                and bool(state.get("analysis"))
+                and not RouterAgent._missing_deliverables(state.get("deliverables", {}))
+            )
+        if route in {"complete_run", "handoff_run"}:
+            run = state.get("run")
+            return bool(state.get("review")) and bool(getattr(run, "result", None))
+        return False
 
     @staticmethod
     def _missing_deliverables(deliverables: Any) -> bool:

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -204,7 +204,12 @@ def test_router_uses_confident_model_route_when_allowed() -> None:
 
     decision = router.decide(
         last_node="content",
-        state={"deliverables": {"deliverables": {"summary": "ready"}}, "execution_profile": object()},
+        state={
+            "raw_result": {"items": [1]},
+            "analysis": {"summary": "ready"},
+            "deliverables": {"deliverables": {"summary": "ready"}},
+            "execution_profile": object(),
+        },
     )
 
     assert decision["next_node"] == "reviewer"
@@ -236,6 +241,27 @@ def test_router_falls_back_when_model_route_is_not_allowed() -> None:
     assert decision["final_route"] == "operator"
     assert decision["used_fallback"] is True
     assert decision["fallback_reason"] == "route_not_allowed"
+
+
+def test_router_falls_back_when_model_route_skips_required_state() -> None:
+    router = RouterAgent(
+        llm_service=FakeRouterLLM(
+            {
+                "route": "content",
+                "reason": "skip directly to content",
+                "confidence": 0.95,
+                "fallback_required": False,
+            }
+        )
+    )
+
+    decision = router.decide(last_node="planner", state={"execution_profile": object()})
+
+    assert decision["next_node"] == "operator"
+    assert decision["decision_source"] == "rule"
+    assert decision["model_route"] == "content"
+    assert decision["used_fallback"] is True
+    assert decision["fallback_reason"] == "route_not_ready"
 
 
 def test_router_falls_back_when_model_confidence_is_low() -> None:

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1,4 +1,5 @@
 from uuid import uuid4
+from types import SimpleNamespace
 
 from fastapi.testclient import TestClient
 
@@ -9,6 +10,20 @@ from app.services import ReviewerAgent, RouterAgent
 
 
 client = TestClient(app)
+
+
+class FakeRouterLLM:
+    def __init__(self, payload: dict | None = None, *, fail: bool = False) -> None:
+        self.payload = payload or {}
+        self.fail = fail
+
+    def generate_json(self, **_: object) -> SimpleNamespace:
+        if self.fail:
+            raise RuntimeError("router unavailable")
+        return SimpleNamespace(
+            payload=self.payload,
+            call=SimpleNamespace(used_fallback=False, error=None, validation_error=None),
+        )
 
 
 def login_as(username: str, password: str) -> None:
@@ -170,6 +185,94 @@ def test_router_requests_one_replan_when_content_is_missing() -> None:
 
     assert decision["next_node"] == "planner"
     assert decision["replan_count"] == 1
+    assert decision["decision_source"] == "rule"
+    assert decision["used_fallback"] is True
+    assert decision["fallback_reason"] == "llm_unavailable"
+
+
+def test_router_uses_confident_model_route_when_allowed() -> None:
+    router = RouterAgent(
+        llm_service=FakeRouterLLM(
+            {
+                "route": "reviewer",
+                "reason": "content is complete enough for review",
+                "confidence": 0.91,
+                "fallback_required": False,
+            }
+        )
+    )
+
+    decision = router.decide(
+        last_node="content",
+        state={"deliverables": {"deliverables": {"summary": "ready"}}, "execution_profile": object()},
+    )
+
+    assert decision["next_node"] == "reviewer"
+    assert decision["decision_source"] == "model"
+    assert decision["model_route"] == "reviewer"
+    assert decision["final_route"] == "reviewer"
+    assert decision["confidence"] == 0.91
+    assert decision["used_fallback"] is False
+    assert decision["fallback_reason"] is None
+
+
+def test_router_falls_back_when_model_route_is_not_allowed() -> None:
+    router = RouterAgent(
+        llm_service=FakeRouterLLM(
+            {
+                "route": "archive_run",
+                "reason": "unsupported target",
+                "confidence": 0.95,
+                "fallback_required": False,
+            }
+        )
+    )
+
+    decision = router.decide(last_node="planner", state={"execution_profile": object()})
+
+    assert decision["next_node"] == "operator"
+    assert decision["decision_source"] == "rule"
+    assert decision["model_route"] == "archive_run"
+    assert decision["final_route"] == "operator"
+    assert decision["used_fallback"] is True
+    assert decision["fallback_reason"] == "route_not_allowed"
+
+
+def test_router_falls_back_when_model_confidence_is_low() -> None:
+    router = RouterAgent(
+        llm_service=FakeRouterLLM(
+            {
+                "route": "reviewer",
+                "reason": "maybe ready",
+                "confidence": 0.69,
+                "fallback_required": False,
+            }
+        )
+    )
+
+    decision = router.decide(last_node="analyst", state={"analysis": {"summary": "ok"}, "execution_profile": object()})
+
+    assert decision["next_node"] == "content"
+    assert decision["decision_source"] == "rule"
+    assert decision["model_route"] == "reviewer"
+    assert decision["confidence"] == 0.69
+    assert decision["used_fallback"] is True
+    assert decision["fallback_reason"] == "low_confidence"
+
+
+def test_router_falls_back_when_model_is_unavailable() -> None:
+    router = RouterAgent(llm_service=FakeRouterLLM(fail=True))
+
+    decision = router.decide(
+        last_node="content",
+        state={"deliverables": {}, "replan_count": 0, "execution_profile": object()},
+    )
+
+    assert decision["next_node"] == "planner"
+    assert decision["decision_source"] == "rule"
+    assert decision["model_route"] is None
+    assert decision["used_fallback"] is True
+    assert decision["fallback_reason"] == "model_error"
 
 
 def test_workflow_result_records_route_decisions() -> None:
@@ -179,6 +282,9 @@ def test_workflow_result_records_route_decisions() -> None:
 
     assert route_decisions[0]["from_node"] == "planner"
     assert route_decisions[0]["next_node"] == "operator"
+    assert route_decisions[0]["final_route"] == "operator"
+    assert "decision_source" in route_decisions[0]
+    assert "used_fallback" in route_decisions[0]
     assert any(item["next_node"] == "reviewer" for item in route_decisions)
 
 


### PR DESCRIPTION
## Summary
- upgrade `RouterAgent` to try structured LLM routing before falling back to the deterministic rule route
- add a local `RouterDecision` schema and route whitelist / confidence gate for model output validation
- extend `route_decisions` with model route, final route, confidence, source, and fallback audit fields
- keep workflow-level LLM log counts stable by testing router model behavior through fake LLM unit tests

## Scope
This is issue #4 Phase 2 only. It builds on the already-merged Phase 1 router from PR #11. It does not add dynamic agent registration, multi-round replanning, supervisor graph rewrites, frontend route-trace UI, or issue #2 tool calling changes.

## Validation
- `python -m pytest tests/test_workflows.py -k "router or graph_endpoint or workflow_result_records_route_decisions" -q` -> 7 passed, 22 deselected
- `python -m pytest -q` -> 29 passed
- `git diff --check` -> clean

Refs #4