### PR TITLE
[codex] show route decisions on run detail page

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -230,6 +230,64 @@ def _build_runtime_memory_sections(run: WorkflowRun) -> list[dict[str, object]]:
     return sections
 
 
+def _build_route_trace_sections(run: WorkflowRun) -> dict[str, object]:
+    decisions = run.result.get("route_decisions", []) if isinstance(run.result, dict) else []
+    if not isinstance(decisions, list):
+        decisions = []
+
+    rows: list[dict[str, object]] = []
+    fallback_count = 0
+    cumulative_replan_count = 0
+    for index, item in enumerate(decisions, start=1):
+        if not isinstance(item, dict):
+            continue
+
+        to_node = str(item.get("final_route") or item.get("next_node") or item.get("route") or "")
+        confidence = item.get("confidence")
+        if isinstance(confidence, (int, float)):
+            confidence_display = f"{float(confidence):.2f}".rstrip("0").rstrip(".")
+        else:
+            confidence_display = "--"
+
+        used_fallback = bool(item.get("used_fallback", False))
+        if used_fallback:
+            fallback_count += 1
+
+        try:
+            item_replan_count = int(item.get("replan_count", 0) or 0)
+        except (TypeError, ValueError):
+            item_replan_count = 0
+        cumulative_replan_count = max(cumulative_replan_count, item_replan_count)
+        is_replan = to_node == "planner" or item_replan_count > 0
+
+        model_route = item.get("model_route")
+        rows.append(
+            {
+                "step": index,
+                "from_node": str(item.get("from_node") or ""),
+                "to_node": to_node,
+                "source": str(item.get("decision_source") or "rule").upper(),
+                "model_route": str(model_route) if model_route else "--",
+                "confidence": confidence_display,
+                "used_fallback": used_fallback,
+                "fallback_reason": str(item.get("fallback_reason") or ""),
+                "reason": str(item.get("reason") or ""),
+                "is_replan": is_replan,
+                "replan_count": item_replan_count,
+            }
+        )
+
+    inferred_replan_count = sum(1 for row in rows if row["is_replan"])
+    replan_count = cumulative_replan_count or inferred_replan_count
+    return {
+        "rows": rows,
+        "total_steps": len(rows),
+        "fallback_count": fallback_count,
+        "replan_count": replan_count,
+        "has_replan": replan_count > 0,
+    }
+
+
 def _build_run_rows(runs: list[WorkflowRun]) -> list[dict]:
     titles = _workflow_titles()
     rows = []
@@ -551,6 +609,7 @@ def run_detail_page(run_id: str, request: Request):
             timeline=_build_timeline(run),
             llm_summary=_build_llm_summary(run),
             runtime_memory_sections=_build_runtime_memory_sections(run),
+            route_trace=_build_route_trace_sections(run),
             result_json=_pretty_json(run.result),
             graph=engine.graph_shape(),
         ),

--- a/app/templates/run_detail.html
+++ b/app/templates/run_detail.html
@@ -60,6 +60,47 @@
   </div>
 </section>
 
+<section class="card" style="margin-top:18px;">
+  <div class="toolbar" style="justify-content:space-between;">
+    <h2 style="margin:0;">路由轨迹</h2>
+    <div class="toolbar">
+      <span class="badge">{{ route_trace.total_steps }} 步路由</span>
+      <span class="badge">发生重规划：{{ "是" if route_trace.has_replan else "否" }}</span>
+      <span class="badge">fallback 次数：{{ route_trace.fallback_count }}</span>
+    </div>
+  </div>
+  {% if route_trace.rows %}
+  <div class="timeline-list" style="margin-top:16px;">
+    {% for row in route_trace.rows %}
+    <div class="timeline-row">
+      <div class="timeline-marker">
+        <div class="timeline-dot"></div>
+      </div>
+      <div class="timeline-card">
+        <div class="timeline-head">
+          <div class="timeline-agent">Step {{ row.step }}: {{ row.from_node }} -> {{ row.to_node }}</div>
+          <div class="toolbar">
+            <span class="badge">{{ row.source }}</span>
+            {% if row.used_fallback %}<span class="badge">FALLBACK</span>{% endif %}
+            {% if row.is_replan %}<span class="badge">REPLAN</span>{% endif %}
+          </div>
+        </div>
+        <div class="timeline-message">{{ row.reason }}</div>
+        <div class="subtle" style="margin-top:8px;">
+          模型建议：{{ row.model_route }}
+          / 置信度：{{ row.confidence }}
+          / replan_count：{{ row.replan_count }}
+          {% if row.fallback_reason %}/ fallback 原因：{{ row.fallback_reason }}{% endif %}
+        </div>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+  {% else %}
+  <div class="subtle" style="margin-top:12px;">暂无路由轨迹（该 run 可能来自旧版本）</div>
+  {% endif %}
+</section>
+
 <div class="grid two" style="margin-top:18px;">
   <section class="card">
     <h2>执行日志</h2>

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -5,7 +5,8 @@ from fastapi.testclient import TestClient
 
 from app.config import Settings
 from app.db import UserAccountRecord
-from app.main import app, database
+from app.main import app, database, repository
+from app.models import RunStatus, WorkflowRun, WorkflowType
 from app.services import ReviewerAgent, RouterAgent
 
 
@@ -360,6 +361,113 @@ def test_run_detail_page_contains_all_export_formats() -> None:
     assert "导出 Markdown" in detail.text
     assert "导出 HTML" in detail.text
     assert "导出 PDF" in detail.text
+
+
+def test_run_detail_page_shows_route_trace_section() -> None:
+    run = WorkflowRun(
+        workflow_type=WorkflowType.SALES_FOLLOWUP,
+        status=RunStatus.COMPLETED,
+        current_step="completed",
+        objective="Route trace phase 1 fixture",
+        result={
+            "route_decisions": [
+                {
+                    "from_node": "planner",
+                    "next_node": "operator",
+                    "reason": "plan is ready; collect or transform source data",
+                    "replan_count": 0,
+                },
+                {
+                    "from_node": "content",
+                    "next_node": "planner",
+                    "reason": "deliverables are missing; request one replanning pass",
+                    "replan_count": 1,
+                },
+            ]
+        },
+    )
+    repository.save(run)
+    login_as("viewer", "viewer123")
+
+    detail = client.get(f"/runs/{run.id}")
+
+    assert detail.status_code == 200
+    assert "路由轨迹" in detail.text
+    assert "2 步路由" in detail.text
+    assert "planner -> operator" in detail.text
+    assert "content -> planner" in detail.text
+    assert "发生重规划：是" in detail.text
+    assert "REPLAN" in detail.text
+    assert "plan is ready; collect or transform source data" in detail.text
+
+
+def test_run_detail_page_handles_empty_route_trace_for_legacy_run() -> None:
+    run = WorkflowRun(
+        workflow_type=WorkflowType.SALES_FOLLOWUP,
+        status=RunStatus.COMPLETED,
+        current_step="completed",
+        objective="Legacy run without route decisions",
+        result={"analysis": {"summary": "legacy result"}},
+    )
+    repository.save(run)
+    login_as("viewer", "viewer123")
+
+    detail = client.get(f"/runs/{run.id}")
+
+    assert detail.status_code == 200
+    assert "路由轨迹" in detail.text
+    assert "暂无路由轨迹（该 run 可能来自旧版本）" in detail.text
+    assert "结果 JSON" in detail.text
+
+
+def test_run_detail_page_shows_route_trace_audit_fields_when_present() -> None:
+    run = WorkflowRun(
+        workflow_type=WorkflowType.SALES_FOLLOWUP,
+        status=RunStatus.COMPLETED,
+        current_step="completed",
+        objective="Route trace phase 2 fixture",
+        result={
+            "route_decisions": [
+                {
+                    "from_node": "content",
+                    "next_node": "reviewer",
+                    "final_route": "reviewer",
+                    "decision_source": "model",
+                    "model_route": "reviewer",
+                    "confidence": 0.91,
+                    "used_fallback": False,
+                    "fallback_reason": None,
+                    "reason": "content is complete enough for review",
+                    "replan_count": 0,
+                },
+                {
+                    "from_node": "planner",
+                    "next_node": "operator",
+                    "final_route": "operator",
+                    "decision_source": "rule",
+                    "model_route": "content",
+                    "confidence": 0.95,
+                    "used_fallback": True,
+                    "fallback_reason": "route_not_ready",
+                    "reason": "plan is ready; collect or transform source data",
+                    "replan_count": 0,
+                },
+            ]
+        },
+    )
+    repository.save(run)
+    login_as("viewer", "viewer123")
+
+    detail = client.get(f"/runs/{run.id}")
+
+    assert detail.status_code == 200
+    assert "MODEL" in detail.text
+    assert "RULE" in detail.text
+    assert "FALLBACK" in detail.text
+    assert "fallback 次数：1" in detail.text
+    assert "模型建议：content" in detail.text
+    assert "置信度：0.95" in detail.text
+    assert "route_not_ready" in detail.text
 
 
 def test_workflow_export_endpoint_supports_markdown_html_and_pdf() -> None:


### PR DESCRIPTION
## Summary
- add a run detail route trace view-model that normalizes Phase 1 and Phase 2 `route_decisions` fields
- render a dedicated 路由轨迹 section with step count, replan status, fallback count, route rows, model audit fields, and legacy empty state
- add TDD coverage for route trace rendering, missing `route_decisions`, and Phase 2 audit metadata

## Scope
This is issue #4 Phase 3 only. It does not change `RouterAgent` decision logic, tool calling, dynamic agent registration, or multi-round replan behavior.

## Validation
- `python -m pytest tests/test_workflows.py -k "run_detail_page and route_trace" -q` -> 3 passed, 30 deselected
- `python -m pytest tests/test_workflows.py -k "run_detail_page or workflow_result_records_route_decisions or router" -q` -> 12 passed, 21 deselected
- `python -m pytest -q` -> 33 passed
- `git diff --check` -> clean, with Windows CRLF working-copy warnings only

Refs #4