### PR TITLE
[codex] add reviewer correction loop routing

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -96,6 +96,8 @@ class ReviewDecision(BaseModel):
     needs_human_review: bool
     score: float
     reasons: list[str] = Field(default_factory=list)
+    correction_target: Literal["analyst", "content"] | None = None
+    correction_reason: str | None = None
 
 
 class WorkflowRequest(BaseModel):
@@ -311,6 +313,8 @@ class ReviewOutput(BaseModel):
     needs_human_review: bool
     score: float
     reasons: list[str]
+    correction_target: Literal["analyst", "content"] | None = None
+    correction_reason: str | None = None
 
     @field_validator("score")
     @classmethod

--- a/app/services.py
+++ b/app/services.py
@@ -61,6 +61,7 @@ class WorkflowState(TypedDict, total=False):
     last_node: str
     next_node: str
     replan_count: int
+    correction_count: int
     route_decisions: list[dict[str, Any]]
     planning_context: dict[str, Any]
     analyst_context: dict[str, Any]
@@ -922,7 +923,10 @@ class ReviewerAgent:
     ) -> tuple[dict[str, Any], Any]:
         fallback = self._rule_review(request.workflow_type, raw_result, analysis, deliverables)
         system_prompt = (
-            "你是企业 AI 工作流中的 ReviewerAgent。请严格返回 JSON，键为 status、needs_human_review、score、reasons，全部使用中文。"
+            "你是企业 AI 工作流中的 ReviewerAgent。请严格返回 JSON，键为 status、needs_human_review、"
+            "score、reasons、correction_target、correction_reason，全部使用中文。"
+            "当输出只需要回到 AnalystAgent 或 ContentAgent 修正时，correction_target 只能为 analyst 或 content；"
+            "不需要修正时 correction_target 为 null。"
         )
         user_prompt = (
             f"Prompt 方案要求：{prompt_profile.reviewer_instruction}\n"
@@ -977,16 +981,22 @@ class ReviewerAgent:
 
         if not reasons:
             reasons.append("结果结构完整，可直接流转执行。")
+        correction_target = None
+        correction_reason = None
         if not analysis or not deliverables:
             needs_human_review = True
             score = min(score, 0.5)
             reasons.append("核心分析或交付结果不完整，需要人工补充。")
+            correction_target = "analyst" if not analysis else "content"
+            correction_reason = "核心分析缺失，需要回到 AnalystAgent 补充。" if not analysis else "交付结果缺失，需要回到 ContentAgent 补充。"
         status = "waiting_human" if needs_human_review else "completed"
         return {
             "status": status,
             "needs_human_review": needs_human_review,
             "score": score,
             "reasons": reasons,
+            "correction_target": correction_target,
+            "correction_reason": correction_reason,
         }
 
     @staticmethod
@@ -1028,11 +1038,28 @@ class ReviewerAgent:
         score = float(model_review.get("score", rule_review.get("score", 0.8)))
         if status == "waiting_human":
             score = min(score, float(rule_review.get("score", score)))
+        rule_correction_target = rule_review.get("correction_target")
+        model_correction_target = model_review.get("correction_target")
+        if rule_correction_target in {"analyst", "content"}:
+            correction_target = rule_correction_target
+        elif bool(rule_review.get("needs_human_review", False)):
+            correction_target = None
+        else:
+            correction_target = model_correction_target
+        if correction_target not in {"analyst", "content"}:
+            correction_target = None
+        correction_reason = str(
+            rule_review.get("correction_reason")
+            if correction_target == rule_correction_target
+            else model_review.get("correction_reason") or ""
+        )
         return {
             "status": status,
             "needs_human_review": status == "waiting_human",
             "score": round(score, 2),
             "reasons": reasons,
+            "correction_target": correction_target,
+            "correction_reason": correction_reason or None,
         }
 
 
@@ -1046,12 +1073,20 @@ class RouterDecision(BaseModel):
 class RouterAgent:
     ALLOWED_ROUTES = {"planner", "operator", "analyst", "content", "reviewer", "complete_run", "handoff_run"}
     MIN_CONFIDENCE = 0.7
+    MAX_CORRECTIONS = 1
 
     def __init__(self, llm_service: LLMService | None = None) -> None:
         self.llm_service = llm_service
 
     def decide(self, *, last_node: str, state: dict[str, Any]) -> dict[str, Any]:
         rule_decision = self._rule_decision(last_node=last_node, state=state)
+        if rule_decision.get("force_rule_route"):
+            return self._build_audit_decision(
+                rule_decision=rule_decision,
+                model_decision=None,
+                used_fallback=True,
+                fallback_reason=rule_decision.get("fallback_reason"),
+            )
         model_decision, fallback_reason = self._model_decision(
             last_node=last_node,
             state=state,
@@ -1073,8 +1108,13 @@ class RouterAgent:
 
     def _rule_decision(self, *, last_node: str, state: dict[str, Any]) -> dict[str, Any]:
         replan_count = int(state.get("replan_count", 0) or 0)
+        correction_count = int(state.get("correction_count", 0) or 0)
         next_node = "complete_run"
         reason = "workflow state is complete"
+        correction_target = None
+        used_correction_loop = False
+        fallback_reason = None
+        force_rule_route = False
 
         if last_node == "planner":
             next_node = "operator"
@@ -1096,7 +1136,22 @@ class RouterAgent:
                 reason = "deliverables are ready for review"
         elif last_node == "reviewer":
             review = state.get("review", {})
-            if isinstance(review, dict) and review.get("status") == "waiting_human":
+            if isinstance(review, dict) and review.get("correction_target") in {"analyst", "content"}:
+                correction_target = str(review["correction_target"])
+                force_rule_route = True
+                if correction_count < self.MAX_CORRECTIONS and self._route_is_state_ready(correction_target, state):
+                    next_node = correction_target
+                    correction_count += 1
+                    used_correction_loop = True
+                    reason = str(
+                        review.get("correction_reason")
+                        or f"reviewer requested a corrective loop to {correction_target}"
+                    )
+                else:
+                    next_node = "handoff_run"
+                    fallback_reason = "correction_limit_reached"
+                    reason = "reviewer requested correction but the correction loop limit was reached"
+            elif isinstance(review, dict) and review.get("status") == "waiting_human":
                 next_node = "handoff_run"
                 reason = "review requires human handoff"
             else:
@@ -1108,6 +1163,11 @@ class RouterAgent:
             "next_node": next_node,
             "reason": reason,
             "replan_count": replan_count,
+            "correction_count": correction_count,
+            "correction_target": correction_target,
+            "used_correction_loop": used_correction_loop,
+            "fallback_reason": fallback_reason,
+            "force_rule_route": force_rule_route,
         }
 
     def _model_decision(
@@ -1178,6 +1238,7 @@ class RouterAgent:
         replan_count = int(rule_decision["replan_count"])
         if not used_fallback and final_route == "planner":
             replan_count += 1
+        fallback_reason = fallback_reason or rule_decision.get("fallback_reason")
         return {
             "from_node": rule_decision["from_node"],
             "next_node": final_route,
@@ -1190,6 +1251,9 @@ class RouterAgent:
             "fallback_reason": fallback_reason,
             "reason": reason,
             "replan_count": replan_count,
+            "correction_count": int(rule_decision.get("correction_count", 0) or 0),
+            "correction_target": rule_decision.get("correction_target"),
+            "used_correction_loop": bool(rule_decision.get("used_correction_loop", False)),
         }
 
     @staticmethod
@@ -1203,11 +1267,13 @@ class RouterAgent:
             "last_node": last_node,
             "workflow_type": workflow_type,
             "replan_count": int(state.get("replan_count", 0) or 0),
+            "correction_count": int(state.get("correction_count", 0) or 0),
             "has_raw_result": bool(state.get("raw_result")),
             "has_analysis": bool(state.get("analysis")),
             "has_deliverables": not RouterAgent._missing_deliverables(deliverables),
             "deliverable_keys": list(nested_deliverables.keys()) if isinstance(nested_deliverables, dict) else [],
             "review_status": review.get("status") if isinstance(review, dict) else None,
+            "review_correction_target": review.get("correction_target") if isinstance(review, dict) else None,
             "rule_route": rule_decision["next_node"],
             "allowed_routes": sorted(RouterAgent.ALLOWED_ROUTES),
         }
@@ -1378,6 +1444,7 @@ class WorkflowEngine:
             "execution_profile": execution_profile,
             "prompt_profile": prompt_profile,
             "replan_count": 0,
+            "correction_count": 0,
             "route_decisions": [],
             "persist": persist,
         }
@@ -1614,6 +1681,7 @@ class WorkflowEngine:
         decision = self.router_agent.decide(last_node=last_node, state=dict(state))
         state["next_node"] = str(decision["next_node"])
         state["replan_count"] = int(decision["replan_count"])
+        state["correction_count"] = int(decision.get("correction_count", state.get("correction_count", 0)) or 0)
         route_decisions = list(state.get("route_decisions", []))
         route_decisions.append(decision)
         state["route_decisions"] = route_decisions

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -6,7 +6,7 @@ from fastapi.testclient import TestClient
 from app.config import Settings
 from app.db import UserAccountRecord
 from app.main import app, database, repository
-from app.models import RunStatus, WorkflowRun, WorkflowType
+from app.models import ReviewDecision, ReviewOutput, RunStatus, WorkflowRun, WorkflowType
 from app.services import ReviewerAgent, RouterAgent
 
 
@@ -300,6 +300,127 @@ def test_router_falls_back_when_model_is_unavailable() -> None:
     assert decision["model_route"] is None
     assert decision["used_fallback"] is True
     assert decision["fallback_reason"] == "model_error"
+
+
+def test_reviewer_output_can_request_content_correction() -> None:
+    review = ReviewOutput(
+        status="completed",
+        needs_human_review=False,
+        score=0.72,
+        reasons=["交付物缺少负责人和截止时间，需要补充内容。"],
+        correction_target="content",
+        correction_reason="补充负责人、截止时间和风险说明。",
+    )
+
+    assert review.correction_target == "content"
+    assert review.correction_reason == "补充负责人、截止时间和风险说明。"
+
+    decision = ReviewDecision(
+        status=RunStatus.COMPLETED,
+        needs_human_review=False,
+        score=review.score,
+        reasons=review.reasons,
+        correction_target=review.correction_target,
+        correction_reason=review.correction_reason,
+    )
+
+    assert decision.correction_target == "content"
+
+
+def test_reviewer_model_correction_does_not_override_rule_handoff() -> None:
+    merged = ReviewerAgent._merge_review(
+        {
+            "status": "waiting_human",
+            "needs_human_review": True,
+            "score": 0.6,
+            "reasons": ["疑似故障类工单必须进入人工接管。"],
+            "correction_target": None,
+            "correction_reason": None,
+        },
+        {
+            "status": "completed",
+            "needs_human_review": False,
+            "score": 0.85,
+            "reasons": ["可以先补充内容。"],
+            "correction_target": "content",
+            "correction_reason": "补充说明。",
+        },
+    )
+
+    assert merged["status"] == "waiting_human"
+    assert merged["needs_human_review"] is True
+    assert merged["correction_target"] is None
+
+
+def test_router_routes_reviewer_correction_to_content_once() -> None:
+    decision = RouterAgent().decide(
+        last_node="reviewer",
+        state={
+            "raw_result": {"items": [1]},
+            "analysis": {"summary": "ready"},
+            "deliverables": {"deliverables": {"summary": "missing owner"}},
+            "review": {
+                "status": "completed",
+                "needs_human_review": False,
+                "correction_target": "content",
+                "correction_reason": "补充负责人和截止时间。",
+            },
+            "correction_count": 0,
+        },
+    )
+
+    assert decision["next_node"] == "content"
+    assert decision["correction_count"] == 1
+    assert decision["correction_target"] == "content"
+    assert decision["used_correction_loop"] is True
+    assert "补充负责人和截止时间" in decision["reason"]
+
+
+def test_router_routes_reviewer_correction_to_analyst_once() -> None:
+    decision = RouterAgent().decide(
+        last_node="reviewer",
+        state={
+            "raw_result": {"items": [1]},
+            "analysis": {"summary": "thin analysis"},
+            "deliverables": {"deliverables": {"summary": "ready"}},
+            "review": {
+                "status": "completed",
+                "needs_human_review": False,
+                "correction_target": "analyst",
+                "correction_reason": "补充根因分析。",
+            },
+            "correction_count": 0,
+        },
+    )
+
+    assert decision["next_node"] == "analyst"
+    assert decision["correction_count"] == 1
+    assert decision["correction_target"] == "analyst"
+    assert decision["used_correction_loop"] is True
+
+
+def test_router_hands_off_when_reviewer_correction_limit_is_reached() -> None:
+    decision = RouterAgent().decide(
+        last_node="reviewer",
+        state={
+            "raw_result": {"items": [1]},
+            "analysis": {"summary": "ready"},
+            "deliverables": {"deliverables": {"summary": "still incomplete"}},
+            "review": {
+                "status": "completed",
+                "needs_human_review": False,
+                "correction_target": "content",
+                "correction_reason": "再次补充内容。",
+            },
+            "correction_count": 1,
+        },
+    )
+
+    assert decision["next_node"] == "handoff_run"
+    assert decision["correction_count"] == 1
+    assert decision["correction_target"] == "content"
+    assert decision["used_correction_loop"] is False
+    assert decision["fallback_reason"] == "correction_limit_reached"
 
 
 def test_workflow_result_records_route_decisions() -> None:


### PR DESCRIPTION
## Summary
- extend reviewer structured output and persisted review decisions with `correction_target` / `correction_reason`
- route reviewer-requested corrections back to `analyst` or `content` once, then hand off if the correction limit is reached
- record correction-loop audit fields in `route_decisions` (`correction_count`, `correction_target`, `used_correction_loop`)
- add router/reviewer TDD coverage for content correction, analyst correction, correction limit, and handoff safety

## Scope
This is issue #4 Phase 4 only. It does not add dynamic agent registration, issue #2 tool calling, unbounded replanning, or supervisor graph restructuring. The only UI impact is existing route trace compatibility through `route_decisions` / result JSON; no broad UI redesign is included.

## Validation
- `python -m pytest tests/test_workflows.py -k "router or reviewer or route" -q` -> 17 passed, 21 deselected
- `python -m pytest -q` -> 38 passed
- `git diff --check` -> clean, with Windows CRLF working-copy warning for `app/models.py` only

Refs #4