### PR TITLE
[codex] add minimal operator tool selection loop

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -288,6 +288,37 @@ def _build_route_trace_sections(run: WorkflowRun) -> dict[str, object]:
     }
 
 
+def _build_operator_context_section(run: WorkflowRun) -> dict[str, object]:
+    if not isinstance(run.result, dict):
+        return {"present": False}
+
+    context = run.result.get("operator_context", {})
+    if not isinstance(context, dict) or not context:
+        return {"present": False}
+
+    confidence = context.get("confidence")
+    if isinstance(confidence, (int, float)):
+        confidence_display = f"{float(confidence):.2f}".rstrip("0").rstrip(".")
+    else:
+        confidence_display = "--"
+
+    tool_choices = context.get("tool_choices", [])
+    if not isinstance(tool_choices, list):
+        tool_choices = []
+
+    return {
+        "present": True,
+        "source": str(context.get("decision_source") or "rule").upper(),
+        "selected_tool": str(context.get("selected_tool") or "--"),
+        "executed_tool": str(context.get("executed_tool") or "--"),
+        "used_fallback": bool(context.get("used_fallback", False)),
+        "fallback_reason": str(context.get("fallback_reason") or ""),
+        "decision_reason": str(context.get("decision_reason") or ""),
+        "confidence": confidence_display,
+        "tool_choices": [str(item) for item in tool_choices if str(item).strip()],
+    }
+
+
 def _build_run_rows(runs: list[WorkflowRun]) -> list[dict]:
     titles = _workflow_titles()
     rows = []
@@ -610,6 +641,7 @@ def run_detail_page(run_id: str, request: Request):
             llm_summary=_build_llm_summary(run),
             runtime_memory_sections=_build_runtime_memory_sections(run),
             route_trace=_build_route_trace_sections(run),
+            operator_context=_build_operator_context_section(run),
             result_json=_pretty_json(run.result),
             graph=engine.graph_shape(),
         ),

--- a/app/models.py
+++ b/app/models.py
@@ -100,6 +100,13 @@ class ReviewDecision(BaseModel):
     correction_reason: str | None = None
 
 
+class OperatorDecision(BaseModel):
+    selected_tool: str
+    reason: str
+    confidence: float = Field(ge=0.0, le=1.0)
+    fallback_required: bool = False
+
+
 class WorkflowRequest(BaseModel):
     model_config = ConfigDict(protected_namespaces=())
 

--- a/app/services.py
+++ b/app/services.py
@@ -23,6 +23,7 @@ from app.models import (
     EvaluationRun,
     ExecutionProfile,
     FeedbackSample,
+    OperatorDecision,
     PromptProfile,
     PromptProfileForm,
     ReviewDecision,
@@ -64,6 +65,7 @@ class WorkflowState(TypedDict, total=False):
     correction_count: int
     route_decisions: list[dict[str, Any]]
     planning_context: dict[str, Any]
+    operator_context: dict[str, Any]
     analyst_context: dict[str, Any]
     content_context: dict[str, Any]
     reviewer_context: dict[str, Any]
@@ -600,17 +602,44 @@ class ToolCenter:
         self.external_data = external_data
 
     def run(self, workflow_type: WorkflowType, payload: dict[str, Any]) -> tuple[dict[str, Any], ToolCall]:
+        return self.run_named(self.default_tool_for(workflow_type, payload), payload)
+
+    def tool_choices_for(self, workflow_type: WorkflowType, payload: dict[str, Any]) -> list[dict[str, str]]:
         if workflow_type == WorkflowType.SALES_FOLLOWUP:
-            result = self._sales_analytics(payload)
-            return result, ToolCall(name="sales_analytics_tool", input=payload, output=result)
+            return [{"name": "sales_analytics_tool", "description": "aggregate funnel and risk metrics"}]
         if workflow_type == WorkflowType.MARKETING_CAMPAIGN:
-            result = self._marketing_brief(payload)
-            return result, ToolCall(name="marketing_brief_tool", input=payload, output=result)
+            return [{"name": "marketing_brief_tool", "description": "prepare campaign brief and channel notes"}]
         if workflow_type == WorkflowType.SUPPORT_TRIAGE:
-            result, tool_name = self._support_triage(payload)
+            choices = [{"name": "support_triage_tool", "description": "classify tickets and escalation risk"}]
+            data_source = payload.get("data_source", {})
+            provider = data_source.get("provider") if isinstance(data_source, dict) else None
+            if provider:
+                choices.append({"name": f"{provider}_tool", "description": f"load support tickets from {provider}"})
+            return choices
+        return [{"name": "meeting_minutes_tool", "description": "extract action items from meeting notes"}]
+
+    def default_tool_for(self, workflow_type: WorkflowType, payload: dict[str, Any]) -> str:
+        choices = self.tool_choices_for(workflow_type, payload)
+        if workflow_type == WorkflowType.SUPPORT_TRIAGE:
+            for item in choices:
+                if item["name"] != "support_triage_tool":
+                    return item["name"]
+        return choices[0]["name"]
+
+    def run_named(self, tool_name: str, payload: dict[str, Any]) -> tuple[dict[str, Any], ToolCall]:
+        if tool_name == "sales_analytics_tool":
+            result = self._sales_analytics(payload)
             return result, ToolCall(name=tool_name, input=payload, output=result)
-        result = self._meeting_extract(payload)
-        return result, ToolCall(name="meeting_minutes_tool", input=payload, output=result)
+        if tool_name == "marketing_brief_tool":
+            result = self._marketing_brief(payload)
+            return result, ToolCall(name=tool_name, input=payload, output=result)
+        if tool_name in {"support_triage_tool", "github_issues_tool", "nyc_311_tool", "stack_overflow_tool", "hacker_news_tool"}:
+            result, actual_name = self._support_triage(payload)
+            return result, ToolCall(name=actual_name, input=payload, output=result)
+        if tool_name == "meeting_minutes_tool":
+            result = self._meeting_extract(payload)
+            return result, ToolCall(name=tool_name, input=payload, output=result)
+        raise ValueError(f"unknown tool: {tool_name}")
 
     def _sales_analytics(self, payload: dict[str, Any]) -> dict[str, Any]:
         region = payload.get("region")
@@ -818,6 +847,115 @@ class AnalystAgent:
                 "自动完成前复核截止时间是否清晰。",
             ],
         }
+
+
+class OperatorAgent:
+    MIN_CONFIDENCE = 0.7
+
+    def __init__(self, tool_center: ToolCenter, llm_service: LLMService | None = None) -> None:
+        self.tool_center = tool_center
+        self.llm_service = llm_service
+
+    def execute(
+        self,
+        *,
+        request: WorkflowRequest,
+        execution_profile: ExecutionProfile,
+    ) -> tuple[dict[str, Any], ToolCall, dict[str, Any], Any]:
+        choices = self.tool_center.tool_choices_for(request.workflow_type, request.input_payload)
+        default_tool = self.tool_center.default_tool_for(request.workflow_type, request.input_payload)
+        model_decision, fallback_reason, llm_call = self._select_tool(
+            request=request,
+            execution_profile=execution_profile,
+            choices=choices,
+            default_tool=default_tool,
+        )
+        if model_decision is not None and fallback_reason is None:
+            raw_result, tool_call = self.tool_center.run_named(model_decision.selected_tool, request.input_payload)
+            return raw_result, tool_call, {
+                "decision_source": "model",
+                "selected_tool": model_decision.selected_tool,
+                "executed_tool": tool_call.name,
+                "used_fallback": False,
+                "fallback_reason": None,
+                "tool_choices": [item["name"] for item in choices],
+                "decision_reason": model_decision.reason,
+                "confidence": model_decision.confidence,
+            }, llm_call
+
+        raw_result, tool_call = self.tool_center.run_named(default_tool, request.input_payload)
+        return raw_result, tool_call, {
+            "decision_source": "rule",
+            "selected_tool": model_decision.selected_tool if model_decision is not None else None,
+            "executed_tool": tool_call.name,
+            "used_fallback": True,
+            "fallback_reason": fallback_reason or "llm_unavailable",
+            "tool_choices": [item["name"] for item in choices],
+            "decision_reason": (
+                model_decision.reason if model_decision is not None else "use deterministic operator tool"
+            ),
+            "confidence": model_decision.confidence if model_decision is not None else None,
+        }, llm_call
+
+    def _select_tool(
+        self,
+        *,
+        request: WorkflowRequest,
+        execution_profile: ExecutionProfile,
+        choices: list[dict[str, str]],
+        default_tool: str,
+    ) -> tuple[OperatorDecision | None, str | None, Any]:
+        if self.llm_service is None:
+            return None, "llm_unavailable", None
+
+        fallback_payload = {
+            "selected_tool": default_tool,
+            "reason": "use deterministic operator tool",
+            "confidence": 0.0,
+            "fallback_required": True,
+        }
+        try:
+            response = self.llm_service.generate_json(
+                route_target="operator",
+                system_prompt=(
+                    "你是企业 AI 工作流中的 OperatorAgent。"
+                    "请严格返回 JSON，键为 selected_tool、reason、confidence、fallback_required。"
+                    "selected_tool 只能从给定的 allowed_tools 中选择。"
+                    "如果信息不足或不确定，请设置 fallback_required=true。"
+                ),
+                user_prompt=json.dumps(
+                    {
+                        "workflow_type": request.workflow_type.value,
+                        "input_payload": request.input_payload,
+                        "allowed_tools": choices,
+                        "default_tool": default_tool,
+                    },
+                    ensure_ascii=False,
+                ),
+                fallback=fallback_payload,
+                execution_profile=execution_profile,
+                response_model=OperatorDecision,
+            )
+        except Exception:
+            return None, "model_error", None
+
+        call = getattr(response, "call", None)
+        if bool(getattr(call, "used_fallback", False)):
+            return None, str(getattr(call, "error", None) or getattr(call, "validation_error", None) or "model_fallback"), call
+
+        try:
+            decision = OperatorDecision.model_validate(response.payload)
+        except ValidationError:
+            return None, "schema_validation_failed", call
+
+        allowed_tools = {item["name"] for item in choices}
+        if decision.selected_tool not in allowed_tools:
+            return decision, "tool_not_allowed", call
+        if decision.confidence < self.MIN_CONFIDENCE:
+            return decision, "low_confidence", call
+        if decision.fallback_required:
+            return decision, "fallback_required", call
+        return decision, None, call
 
 
 class ContentAgent:
@@ -1386,6 +1524,7 @@ class WorkflowEngine:
         self.tool_center = ToolCenter(self.external_data)
         self.llm_service = LLMService(settings)
         self.planner_agent = PlannerAgent(self.llm_service, self.planning_context_tool)
+        self.operator_agent = OperatorAgent(self.tool_center, self.llm_service)
         self.analyst_agent = AnalystAgent(self.llm_service)
         self.content_agent = ContentAgent(self.llm_service)
         self.reviewer_agent = ReviewerAgent(self.llm_service)
@@ -1564,9 +1703,18 @@ class WorkflowEngine:
         run = state["run"]
         request = state["request"]
         run.touch(status=RunStatus.EXECUTING, current_step="operator")
-        raw_result, tool_call = self.tool_center.run(request.workflow_type, request.input_payload)
-        run.add_log("OperatorAgent", f"已完成工具调用：{tool_call.name}。", tool_call=tool_call)
+        raw_result, tool_call, operator_context, llm_call = self.operator_agent.execute(
+            request=request,
+            execution_profile=state["execution_profile"],
+        )
+        run.add_log(
+            "OperatorAgent",
+            f"已执行工具：{tool_call.name}（source={operator_context['decision_source']}）。",
+            tool_call=tool_call,
+            llm_call=llm_call,
+        )
         state["raw_result"] = raw_result
+        state["operator_context"] = operator_context
         state["last_node"] = "operator"
         return state
 
@@ -1655,6 +1803,7 @@ class WorkflowEngine:
         run.result = {
             "execution_profile": state["execution_profile"].model_dump(mode="json"),
             "planning_context": state.get("planning_context", {}),
+            "operator_context": state.get("operator_context", {}),
             "analyst_context": state.get("analyst_context", {}),
             "content_context": state.get("content_context", {}),
             "reviewer_context": reviewer_context,

--- a/app/services.py
+++ b/app/services.py
@@ -633,8 +633,11 @@ class ToolCenter:
         if tool_name == "marketing_brief_tool":
             result = self._marketing_brief(payload)
             return result, ToolCall(name=tool_name, input=payload, output=result)
-        if tool_name in {"support_triage_tool", "github_issues_tool", "nyc_311_tool", "stack_overflow_tool", "hacker_news_tool"}:
-            result, actual_name = self._support_triage(payload)
+        if tool_name == "support_triage_tool":
+            result, actual_name = self._support_triage(payload, use_external_source=False)
+            return result, ToolCall(name=actual_name, input=payload, output=result)
+        if tool_name in {"github_issues_tool", "nyc_311_tool", "stack_overflow_tool", "hacker_news_tool"}:
+            result, actual_name = self._support_triage(payload, use_external_source=True)
             return result, ToolCall(name=actual_name, input=payload, output=result)
         if tool_name == "meeting_minutes_tool":
             result = self._meeting_extract(payload)
@@ -684,12 +687,12 @@ class ToolCenter:
             "channel_notes": {channel: f"为 {channel} 准备一个主卖点和一个行动号召" for channel in channels},
         }
 
-    def _support_triage(self, payload: dict[str, Any]) -> tuple[dict[str, Any], str]:
+    def _support_triage(self, payload: dict[str, Any], *, use_external_source: bool = True) -> tuple[dict[str, Any], str]:
         tickets = payload.get("tickets", [])
         data_source = payload.get("data_source")
         tool_name = "support_triage_tool"
         source_summary: dict[str, Any] = {}
-        if isinstance(data_source, dict) and data_source.get("provider"):
+        if use_external_source and isinstance(data_source, dict) and data_source.get("provider"):
             try:
                 batch = self.external_data.load_support_tickets(data_source)
                 tickets = batch.records

--- a/app/templates/run_detail.html
+++ b/app/templates/run_detail.html
@@ -101,6 +101,45 @@
   {% endif %}
 </section>
 
+<section class="card" style="margin-top:18px;">
+  <div class="toolbar" style="justify-content:space-between;">
+    <h2 style="margin:0;">Operator Decision</h2>
+    {% if operator_context.present %}
+    <div class="toolbar">
+      <span class="badge">{{ operator_context.source }}</span>
+      {% if operator_context.used_fallback %}<span class="badge">FALLBACK</span>{% endif %}
+    </div>
+    {% endif %}
+  </div>
+  {% if operator_context.present %}
+  <div class="grid two" style="margin-top:16px;">
+    <div class="card">
+      <div class="subtle">Selected Tool</div>
+      <div><strong>{{ operator_context.selected_tool }}</strong></div>
+      <div class="subtle" style="margin-top:8px;">confidence: {{ operator_context.confidence }}</div>
+    </div>
+    <div class="card">
+      <div class="subtle">Executed Tool</div>
+      <div><strong>{{ operator_context.executed_tool }}</strong></div>
+      <div class="subtle" style="margin-top:8px;">fallback: {{ "yes" if operator_context.used_fallback else "no" }}</div>
+    </div>
+  </div>
+  <div class="subtle" style="margin-top:12px;">
+    decision reason: {{ operator_context.decision_reason or "--" }}
+    {% if operator_context.fallback_reason %}/ fallback reason: {{ operator_context.fallback_reason }}{% endif %}
+  </div>
+  {% if operator_context.tool_choices %}
+  <div class="toolbar" style="margin-top:12px;">
+    {% for tool_name in operator_context.tool_choices %}
+    <span class="badge">{{ tool_name }}</span>
+    {% endfor %}
+  </div>
+  {% endif %}
+  {% else %}
+  <div class="subtle" style="margin-top:12px;">No operator context recorded (legacy run).</div>
+  {% endif %}
+</section>
+
 <div class="grid two" style="margin-top:18px;">
   <section class="card">
     <h2>执行日志</h2>

--- a/docs/superpowers/plans/2026-04-17-issue-2-minimal-tool-calling.md
+++ b/docs/superpowers/plans/2026-04-17-issue-2-minimal-tool-calling.md
@@ -419,4 +419,3 @@ Expected: no whitespace or patch-format errors
 git add app/services.py tests/test_workflows.py
 git commit -m "test: verify operator tool calling compatibility"
 ```
-

--- a/docs/superpowers/plans/2026-04-17-issue-2-minimal-tool-calling.md
+++ b/docs/superpowers/plans/2026-04-17-issue-2-minimal-tool-calling.md
@@ -1,0 +1,422 @@
+# Issue #2 Minimal Tool Calling Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a minimal model-guided `OperatorAgent` that chooses one allowed tool, executes it once, falls back safely, and persists `operator_context`.
+
+**Architecture:** Keep the existing workflow graph and downstream agent contracts intact. Add a small `OperatorDecision` schema plus an `OperatorAgent` wrapper around the current `ToolCenter`, and only refactor `ToolCenter` enough to expose tool allowlists, deterministic defaults, and named execution. Persist `operator_context` beside `raw_result` so operator behavior becomes auditable without introducing multi-turn tool loops.
+
+**Tech Stack:** Python 3.11, FastAPI, Pydantic, LangGraph, pytest
+
+---
+
+### Task 1: Add failing operator decision tests
+
+**Files:**
+- Modify: `tests/test_workflows.py`
+- Test: `tests/test_workflows.py`
+
+- [ ] **Step 1: Write the failing unit tests for operator model selection and fallback**
+
+```python
+class FakeOperatorLLM:
+    def __init__(self, payload: dict | None = None, *, fail: bool = False) -> None:
+        self.payload = payload or {}
+        self.fail = fail
+
+    def generate_json(self, **_: object) -> SimpleNamespace:
+        if self.fail:
+            raise RuntimeError("operator unavailable")
+        return SimpleNamespace(
+            payload=self.payload,
+            call=SimpleNamespace(used_fallback=False, error=None, validation_error=None),
+        )
+
+
+def test_operator_uses_model_selected_tool_when_allowed() -> None:
+    tool_center = ToolCenter(ExternalDataService(Settings()))
+    operator = OperatorAgent(llm_service=FakeOperatorLLM(
+        {
+            "selected_tool": "sales_analytics_tool",
+            "reason": "need funnel metrics first",
+            "confidence": 0.93,
+            "fallback_required": False,
+        }
+    ), tool_center=tool_center)
+
+    raw_result, tool_call, operator_context, llm_call = operator.execute(
+        request=WorkflowRequest(
+            workflow_type=WorkflowType.SALES_FOLLOWUP,
+            input_payload={"period": "2026-W13", "region": "华东"},
+        ),
+        execution_profile=object(),
+    )
+
+    assert tool_call.name == "sales_analytics_tool"
+    assert operator_context["decision_source"] == "model"
+    assert operator_context["executed_tool"] == "sales_analytics_tool"
+    assert operator_context["used_fallback"] is False
+    assert llm_call is not None
+    assert raw_result["lead_count"] > 0
+
+
+def test_operator_falls_back_when_selected_tool_is_not_allowed() -> None:
+    tool_center = ToolCenter(ExternalDataService(Settings()))
+    operator = OperatorAgent(llm_service=FakeOperatorLLM(
+        {
+            "selected_tool": "marketing_brief_tool",
+            "reason": "wrong tool",
+            "confidence": 0.95,
+            "fallback_required": False,
+        }
+    ), tool_center=tool_center)
+
+    _, tool_call, operator_context, _ = operator.execute(
+        request=WorkflowRequest(
+            workflow_type=WorkflowType.SALES_FOLLOWUP,
+            input_payload={"period": "2026-W13"},
+        ),
+        execution_profile=object(),
+    )
+
+    assert tool_call.name == "sales_analytics_tool"
+    assert operator_context["decision_source"] == "rule"
+    assert operator_context["used_fallback"] is True
+    assert operator_context["fallback_reason"] == "tool_not_allowed"
+
+
+def test_operator_falls_back_when_confidence_is_low() -> None:
+    tool_center = ToolCenter(ExternalDataService(Settings()))
+    operator = OperatorAgent(llm_service=FakeOperatorLLM(
+        {
+            "selected_tool": "sales_analytics_tool",
+            "reason": "not sure",
+            "confidence": 0.61,
+            "fallback_required": False,
+        }
+    ), tool_center=tool_center)
+
+    _, tool_call, operator_context, _ = operator.execute(
+        request=WorkflowRequest(
+            workflow_type=WorkflowType.SALES_FOLLOWUP,
+            input_payload={"period": "2026-W13"},
+        ),
+        execution_profile=object(),
+    )
+
+    assert tool_call.name == "sales_analytics_tool"
+    assert operator_context["used_fallback"] is True
+    assert operator_context["fallback_reason"] == "low_confidence"
+
+
+def test_operator_falls_back_when_model_is_unavailable() -> None:
+    tool_center = ToolCenter(ExternalDataService(Settings()))
+    operator = OperatorAgent(llm_service=FakeOperatorLLM(fail=True), tool_center=tool_center)
+
+    _, tool_call, operator_context, llm_call = operator.execute(
+        request=WorkflowRequest(
+            workflow_type=WorkflowType.SALES_FOLLOWUP,
+            input_payload={"period": "2026-W13"},
+        ),
+        execution_profile=object(),
+    )
+
+    assert tool_call.name == "sales_analytics_tool"
+    assert operator_context["used_fallback"] is True
+    assert operator_context["fallback_reason"] == "model_error"
+    assert llm_call is None
+```
+
+- [ ] **Step 2: Run the operator-focused tests to verify RED**
+
+Run: `python -m pytest tests/test_workflows.py -k "operator_uses_model_selected_tool_when_allowed or operator_falls_back_when_selected_tool_is_not_allowed or operator_falls_back_when_confidence_is_low or operator_falls_back_when_model_is_unavailable" -q`
+
+Expected: FAIL because `OperatorAgent` and `OperatorDecision` do not exist yet.
+
+- [ ] **Step 3: Add a failing workflow-level persistence test**
+
+```python
+def test_workflow_run_persists_operator_context() -> None:
+    body = create_sales_run()
+
+    assert "operator_context" in body["result"]
+    assert "executed_tool" in body["result"]["operator_context"]
+    assert "used_fallback" in body["result"]["operator_context"]
+```
+
+- [ ] **Step 4: Run the persistence test to verify RED**
+
+Run: `python -m pytest tests/test_workflows.py -k "workflow_run_persists_operator_context" -q`
+
+Expected: FAIL because `operator_context` is not persisted yet.
+
+- [ ] **Step 5: Commit the red tests**
+
+```bash
+git add tests/test_workflows.py
+git commit -m "test: add operator tool selection red tests"
+```
+
+### Task 2: Implement OperatorDecision and minimal ToolCenter registry support
+
+**Files:**
+- Modify: `app/models.py`
+- Modify: `app/services.py`
+- Test: `tests/test_workflows.py`
+
+- [ ] **Step 1: Add `OperatorDecision` to `app/models.py`**
+
+```python
+class OperatorDecision(BaseModel):
+    selected_tool: str
+    reason: str
+    confidence: float = Field(ge=0.0, le=1.0)
+    fallback_required: bool = False
+```
+
+- [ ] **Step 2: Add minimal tool registry helpers to `ToolCenter`**
+
+```python
+def tool_choices_for(self, workflow_type: WorkflowType, payload: dict[str, Any]) -> list[dict[str, str]]:
+    if workflow_type == WorkflowType.SALES_FOLLOWUP:
+        return [{"name": "sales_analytics_tool", "description": "aggregate funnel and risk metrics"}]
+    if workflow_type == WorkflowType.MARKETING_CAMPAIGN:
+        return [{"name": "marketing_brief_tool", "description": "prepare campaign brief and channel notes"}]
+    if workflow_type == WorkflowType.SUPPORT_TRIAGE:
+        choices = [{"name": "support_triage_tool", "description": "classify tickets and escalation risk"}]
+        data_source = payload.get("data_source", {})
+        provider = data_source.get("provider") if isinstance(data_source, dict) else None
+        if provider:
+            choices.append({"name": f"{provider}_tool", "description": f"load support tickets from {provider}"})
+        return choices
+    return [{"name": "meeting_minutes_tool", "description": "extract action items from meeting notes"}]
+
+
+def default_tool_for(self, workflow_type: WorkflowType, payload: dict[str, Any]) -> str:
+    choices = self.tool_choices_for(workflow_type, payload)
+    if workflow_type == WorkflowType.SUPPORT_TRIAGE:
+        for item in choices:
+            if item["name"] != "support_triage_tool":
+                return item["name"]
+    return choices[0]["name"]
+```
+
+- [ ] **Step 3: Add named execution entrypoint to `ToolCenter`**
+
+```python
+def run_named(self, tool_name: str, payload: dict[str, Any]) -> tuple[dict[str, Any], ToolCall]:
+    if tool_name == "sales_analytics_tool":
+        result = self._sales_analytics(payload)
+        return result, ToolCall(name=tool_name, input=payload, output=result)
+    if tool_name == "marketing_brief_tool":
+        result = self._marketing_brief(payload)
+        return result, ToolCall(name=tool_name, input=payload, output=result)
+    if tool_name in {"support_triage_tool", "github_issues_tool", "nyc_311_tool", "stack_overflow_tool", "hacker_news_tool"}:
+        result, actual_name = self._support_triage(payload)
+        return result, ToolCall(name=actual_name, input=payload, output=result)
+    if tool_name == "meeting_minutes_tool":
+        result = self._meeting_extract(payload)
+        return result, ToolCall(name=tool_name, input=payload, output=result)
+    raise ValueError(f"unknown tool: {tool_name}")
+```
+
+- [ ] **Step 4: Run the focused tests and keep them red only on missing operator execution logic**
+
+Run: `python -m pytest tests/test_workflows.py -k "operator or workflow_run_persists_operator_context" -q`
+
+Expected: FAIL because the schema exists but `OperatorAgent` and workflow persistence still do not.
+
+- [ ] **Step 5: Commit the registry/schema groundwork**
+
+```bash
+git add app/models.py app/services.py
+git commit -m "feat: add operator decision schema and tool registry helpers"
+```
+
+### Task 3: Implement OperatorAgent and wire operator_context into workflow results
+
+**Files:**
+- Modify: `app/services.py`
+- Modify: `tests/test_workflows.py`
+- Test: `tests/test_workflows.py`
+
+- [ ] **Step 1: Add `operator_context` to workflow state and result payload shape**
+
+```python
+class WorkflowState(TypedDict, total=False):
+    ...
+    operator_context: dict[str, Any]
+```
+
+And include it when building `run.result`:
+
+```python
+"operator_context": state.get("operator_context", {}),
+```
+
+- [ ] **Step 2: Implement minimal `OperatorAgent`**
+
+```python
+class OperatorAgent:
+    MIN_CONFIDENCE = 0.7
+
+    def __init__(self, tool_center: ToolCenter, llm_service: LLMService | None = None) -> None:
+        self.tool_center = tool_center
+        self.llm_service = llm_service
+
+    def execute(self, *, request: WorkflowRequest, execution_profile: ExecutionProfile) -> tuple[dict[str, Any], ToolCall, dict[str, Any], Any]:
+        choices = self.tool_center.tool_choices_for(request.workflow_type, request.input_payload)
+        default_tool = self.tool_center.default_tool_for(request.workflow_type, request.input_payload)
+        model_decision, fallback_reason, llm_call = self._select_tool(
+            request=request,
+            execution_profile=execution_profile,
+            choices=choices,
+            default_tool=default_tool,
+        )
+        if model_decision is not None and fallback_reason is None:
+            raw_result, tool_call = self.tool_center.run_named(model_decision.selected_tool, request.input_payload)
+            return raw_result, tool_call, {
+                "decision_source": "model",
+                "selected_tool": model_decision.selected_tool,
+                "executed_tool": tool_call.name,
+                "used_fallback": False,
+                "fallback_reason": None,
+                "tool_choices": [item["name"] for item in choices],
+                "decision_reason": model_decision.reason,
+                "confidence": model_decision.confidence,
+            }, llm_call
+        raw_result, tool_call = self.tool_center.run_named(default_tool, request.input_payload)
+        return raw_result, tool_call, {
+            "decision_source": "rule",
+            "selected_tool": model_decision.selected_tool if model_decision is not None else None,
+            "executed_tool": tool_call.name,
+            "used_fallback": True,
+            "fallback_reason": fallback_reason or "llm_unavailable",
+            "tool_choices": [item["name"] for item in choices],
+            "decision_reason": model_decision.reason if model_decision is not None else "use deterministic operator tool",
+            "confidence": model_decision.confidence if model_decision is not None else None,
+        }, llm_call
+```
+
+- [ ] **Step 3: Add `_select_tool()` validation inside `OperatorAgent`**
+
+```python
+def _select_tool(...):
+    if self.llm_service is None or execution_profile is None:
+        return None, "llm_unavailable", None
+    fallback_payload = {
+        "selected_tool": default_tool,
+        "reason": "use deterministic operator tool",
+        "confidence": 0.0,
+        "fallback_required": True,
+    }
+    try:
+        response = self.llm_service.generate_json(
+            route_target="operator",
+            system_prompt="...",
+            user_prompt=json.dumps({...}, ensure_ascii=False),
+            fallback=fallback_payload,
+            execution_profile=execution_profile,
+            response_model=OperatorDecision,
+        )
+    except Exception:
+        return None, "model_error", None
+
+    call = getattr(response, "call", None)
+    try:
+        decision = OperatorDecision.model_validate(response.payload)
+    except ValidationError:
+        return None, "schema_validation_failed", call
+    allowed_tools = {item["name"] for item in choices}
+    if decision.selected_tool not in allowed_tools:
+        return decision, "tool_not_allowed", call
+    if decision.confidence < self.MIN_CONFIDENCE:
+        return decision, "low_confidence", call
+    if decision.fallback_required:
+        return decision, "fallback_required", call
+    return decision, None, call
+```
+
+- [ ] **Step 4: Wire `_operator_step()` through `OperatorAgent`**
+
+```python
+def _operator_step(self, state: WorkflowState) -> WorkflowState:
+    run = state["run"]
+    request = state["request"]
+    run.touch(status=RunStatus.EXECUTING, current_step="operator")
+    raw_result, tool_call, operator_context, llm_call = self.operator_agent.execute(
+        request=request,
+        execution_profile=state["execution_profile"],
+    )
+    run.add_log(
+        "OperatorAgent",
+        f"已执行工具：{tool_call.name}（source={operator_context['decision_source']}）。",
+        tool_call=tool_call,
+        llm_call=llm_call,
+    )
+    state["raw_result"] = raw_result
+    state["operator_context"] = operator_context
+    state["last_node"] = "operator"
+    return state
+```
+
+- [ ] **Step 5: Update engine initialization to construct `OperatorAgent`**
+
+```python
+self.operator_agent = OperatorAgent(self.tool_center, self.llm_service)
+```
+
+- [ ] **Step 6: Run operator-focused tests to verify GREEN**
+
+Run: `python -m pytest tests/test_workflows.py -k "operator or workflow_run_persists_operator_context" -q`
+
+Expected: PASS
+
+- [ ] **Step 7: Commit the operator minimal loop**
+
+```bash
+git add app/services.py tests/test_workflows.py
+git commit -m "feat: add minimal operator tool selection loop"
+```
+
+### Task 4: Verify compatibility and full suite stability
+
+**Files:**
+- Modify: `tests/test_workflows.py` (only if compatibility assertions need minor updates)
+- Test: `tests/test_workflows.py`
+
+- [ ] **Step 1: Add or tighten a compatibility assertion on workflow results**
+
+```python
+def test_sales_workflow_runs_with_selected_model_prompt_and_routing() -> None:
+    body = create_sales_run()
+    ...
+    assert "operator_context" in body["result"]
+    assert body["result"]["operator_context"]["executed_tool"] == "sales_analytics_tool"
+```
+
+- [ ] **Step 2: Run focused workflow/operator verification**
+
+Run: `python -m pytest tests/test_workflows.py -k "operator or workflow" -q`
+
+Expected: PASS
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `python -m pytest -q`
+
+Expected: PASS
+
+- [ ] **Step 4: Run diff hygiene check**
+
+Run: `git diff --check`
+
+Expected: no whitespace or patch-format errors
+
+- [ ] **Step 5: Commit the verification-compatible final state**
+
+```bash
+git add app/services.py tests/test_workflows.py
+git commit -m "test: verify operator tool calling compatibility"
+```
+

--- a/docs/superpowers/specs/2026-04-17-issue-2-minimal-tool-calling-design.md
+++ b/docs/superpowers/specs/2026-04-17-issue-2-minimal-tool-calling-design.md
@@ -197,4 +197,3 @@ This phase is complete when:
 - `operator_context` is persisted and auditable
 - existing workflow behavior remains compatible
 - targeted tests and full test suite pass
-

--- a/docs/superpowers/specs/2026-04-17-issue-2-minimal-tool-calling-design.md
+++ b/docs/superpowers/specs/2026-04-17-issue-2-minimal-tool-calling-design.md
@@ -1,0 +1,200 @@
+# Issue #2 Minimal Tool Calling Design
+
+## Goal
+
+Upgrade `OperatorAgent` from a fixed `ToolCenter.run()` dispatcher into a minimal model-guided tool selection step that still preserves the current workflow contract.
+
+This round is intentionally limited to a single tool decision and a single tool execution. It does not attempt to build a multi-turn observe -> replan -> tool loop.
+
+## Problem Statement
+
+Current operator behavior is hard-coded in `WorkflowEngine._operator_step()`:
+
+- it does not ask the model whether a tool should be used
+- it does not let the model choose among multiple tools
+- it does not persist operator decision metadata beyond the raw `ToolCall`
+- it keeps tool selection logic concentrated inside `ToolCenter.run(workflow_type, payload)`
+
+This leaves `OperatorAgent` as a fixed execution node rather than an agentic tool user.
+
+## Scope
+
+This design only includes:
+
+- one structured `OperatorDecision` model
+- one model decision attempt per workflow run
+- one tool execution per operator step
+- deterministic fallback to the current workflow-type-based tool path
+- persisted operator audit context in run results
+- focused tests for success and fallback paths
+
+## Out of Scope
+
+This design explicitly does not include:
+
+- multi-round tool calling
+- observe -> replan -> tool re-entry
+- dynamic agent registration
+- changes to `RouterAgent` behavior
+- cleanup scripts, pollution repair, or unrelated observability work
+- UI redesign beyond existing JSON/result visibility
+- tool-calling changes for `AnalystAgent`, `ContentAgent`, or `ReviewerAgent`
+
+## Recommended Approach
+
+Use a minimal layered design:
+
+1. Introduce a small `OperatorDecision` schema for model output.
+2. Refactor `ToolCenter` just enough to expose an allowed tool list and a unified execution entrypoint.
+3. Add an `OperatorAgent` that chooses a tool with LLM structured output, then executes exactly one tool.
+4. Fall back to the current deterministic tool path whenever the model is unavailable, invalid, low-confidence, or asks for fallback.
+5. Persist `operator_context` so the decision path is auditable.
+
+This keeps the blast radius small and avoids repeating the oversized scope of PR #6.
+
+## Architecture
+
+### 1. OperatorDecision
+
+Add a local structured model for operator routing:
+
+- `selected_tool: str`
+- `reason: str`
+- `confidence: float`
+- `fallback_required: bool`
+
+Validation rules:
+
+- `selected_tool` must be in the tool allowlist for the current workflow
+- `confidence` must be between `0.0` and `1.0`
+- if `confidence < 0.7`, the engine must fall back
+- if `fallback_required == true`, the engine must fall back
+
+### 2. Tool Registry Shape
+
+Do not introduce a large generic framework yet. Keep `ToolCenter` as the owner of tool execution, but split responsibilities:
+
+- `tool_choices_for(workflow_type, payload) -> list[dict[str, str]]`
+- `default_tool_for(workflow_type, payload) -> str`
+- `run_named(tool_name, payload) -> tuple[dict[str, Any], ToolCall]`
+
+Current concrete tools remain the same logical tools already embedded in `ToolCenter`:
+
+- `sales_analytics_tool`
+- `marketing_brief_tool`
+- `support_triage_tool` and provider-backed support variants
+- `meeting_minutes_tool`
+
+For this round, each workflow may still expose only one or a small fixed set of tools. The important change is that the operator selects from an explicit allowlist instead of `WorkflowEngine` directly dispatching by workflow type.
+
+### 3. OperatorAgent
+
+Add a dedicated `OperatorAgent` with a method shaped roughly like:
+
+- input: `WorkflowRequest`, optional memory/context, execution profile
+- output: `raw_result`, `ToolCall`, `operator_context`, optional `llm_call`
+
+Decision flow:
+
+1. Build the allowed tool list for the current workflow.
+2. Ask the model for a structured `OperatorDecision`.
+3. Validate the tool selection.
+4. If valid, execute the named tool exactly once.
+5. If invalid or unavailable, execute the deterministic default tool.
+
+### 4. operator_context
+
+Persist a minimal operator audit structure in `run.result`:
+
+- `decision_source`: `model` or `rule`
+- `selected_tool`: tool requested by model, or `null`
+- `executed_tool`: tool actually run
+- `used_fallback`: bool
+- `fallback_reason`: string or `null`
+- `tool_choices`: allowed tool names for this request
+- `decision_reason`: operator reasoning text
+- `confidence`: model confidence, if present
+
+This is enough for auditability now and provides a stable base for future multi-turn operator work.
+
+## Workflow Integration
+
+`WorkflowEngine._operator_step()` should stop calling `ToolCenter.run()` directly.
+
+Instead it should:
+
+1. call `OperatorAgent.execute(...)`
+2. store `state["raw_result"]`
+3. store `state["operator_context"]`
+4. log both the operator LLM call and the concrete tool call
+
+`run.result` should include `operator_context` alongside the existing execution/profile/result fields.
+
+## Error Handling
+
+Fallback must occur in any of these conditions:
+
+- LLM disabled
+- operator model call raises
+- JSON parsing or schema validation fails
+- `selected_tool` not in current allowlist
+- `confidence < 0.7`
+- `fallback_required == true`
+
+Fallback behavior must preserve current user-visible workflow compatibility by running the same deterministic tool path used today.
+
+## Testing Strategy
+
+Use TDD and keep tests independent from planner/analyst/content/reviewer call-count assertions.
+
+Minimum tests:
+
+1. operator uses model-selected tool when selection is valid
+2. operator falls back when selected tool is not allowed
+3. operator falls back when confidence is below threshold
+4. operator falls back when model is unavailable
+5. workflow run persists `operator_context`
+6. fallback path preserves current raw result shape for existing workflow tests
+
+Full test command for this round remains:
+
+- `python -m pytest tests/test_workflows.py -k "operator or workflow" -q`
+- `python -m pytest -q`
+
+The exact focused selector can be adjusted once the final test names exist, but the new tests should stay narrow and operator-specific.
+
+## Low-Risk Follow-Ons
+
+These are acceptable to include only if they remain tightly scoped and do not broaden the PR:
+
+- add one helper for operator tool choice normalization to keep `services.py` readable
+- add one compact operator result summary string in logs
+
+These should not be included in this round:
+
+- cleanup database scripts
+- review queue UI changes
+- observability dashboards
+- additional agent memory expansions
+
+## Implementation Boundaries
+
+The implementation should prefer:
+
+- adding `OperatorDecision` near existing local structured models
+- adding `OperatorAgent` beside the other agents in `app/services.py`
+- minimizing changes to template files
+- avoiding broad refactors to unrelated agent code
+
+If `app/services.py` starts growing awkwardly during implementation, the only acceptable structural extraction in this round is a narrowly-scoped helper for operator tool resolution. No general framework refactor.
+
+## Success Criteria
+
+This phase is complete when:
+
+- `OperatorAgent` performs one structured tool selection attempt
+- invalid model output safely falls back to the current deterministic path
+- `operator_context` is persisted and auditable
+- existing workflow behavior remains compatible
+- targeted tests and full test suite pass
+

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -722,6 +722,58 @@ def test_run_detail_page_shows_route_trace_audit_fields_when_present() -> None:
     assert "route_not_ready" in detail.text
 
 
+def test_run_detail_page_shows_operator_context_when_present() -> None:
+    run = WorkflowRun(
+        workflow_type=WorkflowType.SALES_FOLLOWUP,
+        status=RunStatus.COMPLETED,
+        current_step="completed",
+        objective="Operator context fixture",
+        result={
+            "operator_context": {
+                "decision_source": "model",
+                "selected_tool": "sales_analytics_tool",
+                "executed_tool": "sales_analytics_tool",
+                "used_fallback": False,
+                "fallback_reason": None,
+                "tool_choices": ["sales_analytics_tool"],
+                "decision_reason": "need funnel metrics first",
+                "confidence": 0.93,
+            }
+        },
+    )
+    repository.save(run)
+    login_as("viewer", "viewer123")
+
+    detail = client.get(f"/runs/{run.id}")
+
+    assert detail.status_code == 200
+    assert "Operator Decision" in detail.text
+    assert "MODEL" in detail.text
+    assert "Selected Tool" in detail.text
+    assert "Executed Tool" in detail.text
+    assert "sales_analytics_tool" in detail.text
+    assert "need funnel metrics first" in detail.text
+    assert "0.93" in detail.text
+
+
+def test_run_detail_page_handles_missing_operator_context() -> None:
+    run = WorkflowRun(
+        workflow_type=WorkflowType.SALES_FOLLOWUP,
+        status=RunStatus.COMPLETED,
+        current_step="completed",
+        objective="Legacy run without operator context",
+        result={"analysis": {"summary": "legacy result"}},
+    )
+    repository.save(run)
+    login_as("viewer", "viewer123")
+
+    detail = client.get(f"/runs/{run.id}")
+
+    assert detail.status_code == 200
+    assert "Operator Decision" in detail.text
+    assert "No operator context recorded (legacy run)." in detail.text
+
+
 def test_workflow_export_endpoint_supports_markdown_html_and_pdf() -> None:
     created = create_sales_run()
     markdown = client.get(f"/runs/{created['id']}/export?format=markdown")

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -349,6 +349,42 @@ def test_operator_uses_model_selected_tool_when_allowed() -> None:
     assert raw_result["lead_count"] > 0
 
 
+def test_operator_respects_model_selected_support_triage_tool_with_data_source() -> None:
+    class RejectingExternalData(ExternalDataService):
+        def load_support_tickets(self, source: dict) -> object:
+            raise AssertionError("external provider should not be called")
+
+    tool_center = ToolCenter(RejectingExternalData(Settings()))
+    operator = OperatorAgent(
+        llm_service=FakeOperatorLLM(
+            {
+                "selected_tool": "support_triage_tool",
+                "reason": "use local tickets from payload",
+                "confidence": 0.9,
+                "fallback_required": False,
+            }
+        ),
+        tool_center=tool_center,
+    )
+
+    raw_result, tool_call, operator_context, _ = operator.execute(
+        request=WorkflowRequest(
+            workflow_type=WorkflowType.SUPPORT_TRIAGE,
+            input_payload={
+                "tickets": [{"customer": "ACME", "message": "invoice question"}],
+                "data_source": {"provider": "github_issues"},
+            },
+        ),
+        execution_profile=object(),
+    )
+
+    assert tool_call.name == "support_triage_tool"
+    assert operator_context["decision_source"] == "model"
+    assert operator_context["selected_tool"] == "support_triage_tool"
+    assert operator_context["executed_tool"] == "support_triage_tool"
+    assert raw_result["tickets"][0]["customer"] == "ACME"
+
+
 def test_operator_falls_back_when_selected_tool_is_not_allowed() -> None:
     tool_center = ToolCenter(ExternalDataService(Settings()))
     operator = OperatorAgent(

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -5,9 +5,10 @@ from fastapi.testclient import TestClient
 
 from app.config import Settings
 from app.db import UserAccountRecord
+from app.external_data import ExternalDataService
 from app.main import app, database, repository
-from app.models import ReviewDecision, ReviewOutput, RunStatus, WorkflowRun, WorkflowType
-from app.services import ReviewerAgent, RouterAgent
+from app.models import ReviewDecision, ReviewOutput, RunStatus, WorkflowRequest, WorkflowRun, WorkflowType
+from app.services import OperatorAgent, ReviewerAgent, RouterAgent, ToolCenter
 
 
 client = TestClient(app)
@@ -21,6 +22,20 @@ class FakeRouterLLM:
     def generate_json(self, **_: object) -> SimpleNamespace:
         if self.fail:
             raise RuntimeError("router unavailable")
+        return SimpleNamespace(
+            payload=self.payload,
+            call=SimpleNamespace(used_fallback=False, error=None, validation_error=None),
+        )
+
+
+class FakeOperatorLLM:
+    def __init__(self, payload: dict | None = None, *, fail: bool = False) -> None:
+        self.payload = payload or {}
+        self.fail = fail
+
+    def generate_json(self, **_: object) -> SimpleNamespace:
+        if self.fail:
+            raise RuntimeError("operator unavailable")
         return SimpleNamespace(
             payload=self.payload,
             call=SimpleNamespace(used_fallback=False, error=None, validation_error=None),
@@ -169,13 +184,15 @@ def test_sales_workflow_runs_with_selected_model_prompt_and_routing() -> None:
     assert body["result"]["execution_profile"]["prompt_profile"]["profile_id"] == "ops-deep-v1"
     assert body["result"]["execution_profile"]["routing_policy"]["policy_id"] == "balanced-router-v1"
     assert "planning_context" in body["result"]
+    assert "operator_context" in body["result"]
     assert "memory" in body["result"]["planning_context"]
+    assert body["result"]["operator_context"]["executed_tool"] == "sales_analytics_tool"
     planner_logs = [log for log in body["logs"] if log["agent"] == "PlannerAgent"]
     assert len(planner_logs) == 1
     assert planner_logs[0]["tool_call"]["name"] == "planning_context_tool"
     llm_logs = [log for log in body["logs"] if log.get("llm_call")]
-    assert len(llm_logs) == 4
-    assert {log["llm_call"]["route_target"] for log in llm_logs} == {"planner", "analyst", "content", "reviewer"}
+    assert len(llm_logs) == 5
+    assert {log["llm_call"]["route_target"] for log in llm_logs} == {"planner", "operator", "analyst", "content", "reviewer"}
 
 
 def test_router_requests_one_replan_when_content_is_missing() -> None:
@@ -300,6 +317,112 @@ def test_router_falls_back_when_model_is_unavailable() -> None:
     assert decision["model_route"] is None
     assert decision["used_fallback"] is True
     assert decision["fallback_reason"] == "model_error"
+
+
+def test_operator_uses_model_selected_tool_when_allowed() -> None:
+    tool_center = ToolCenter(ExternalDataService(Settings()))
+    operator = OperatorAgent(
+        llm_service=FakeOperatorLLM(
+            {
+                "selected_tool": "sales_analytics_tool",
+                "reason": "need funnel metrics first",
+                "confidence": 0.93,
+                "fallback_required": False,
+            }
+        ),
+        tool_center=tool_center,
+    )
+
+    raw_result, tool_call, operator_context, llm_call = operator.execute(
+        request=WorkflowRequest(
+            workflow_type=WorkflowType.SALES_FOLLOWUP,
+            input_payload={"period": "2026-W13", "region": "华东"},
+        ),
+        execution_profile=object(),
+    )
+
+    assert tool_call.name == "sales_analytics_tool"
+    assert operator_context["decision_source"] == "model"
+    assert operator_context["executed_tool"] == "sales_analytics_tool"
+    assert operator_context["used_fallback"] is False
+    assert llm_call is not None
+    assert raw_result["lead_count"] > 0
+
+
+def test_operator_falls_back_when_selected_tool_is_not_allowed() -> None:
+    tool_center = ToolCenter(ExternalDataService(Settings()))
+    operator = OperatorAgent(
+        llm_service=FakeOperatorLLM(
+            {
+                "selected_tool": "marketing_brief_tool",
+                "reason": "wrong tool",
+                "confidence": 0.95,
+                "fallback_required": False,
+            }
+        ),
+        tool_center=tool_center,
+    )
+
+    _, tool_call, operator_context, _ = operator.execute(
+        request=WorkflowRequest(
+            workflow_type=WorkflowType.SALES_FOLLOWUP,
+            input_payload={"period": "2026-W13"},
+        ),
+        execution_profile=object(),
+    )
+
+    assert tool_call.name == "sales_analytics_tool"
+    assert operator_context["decision_source"] == "rule"
+    assert operator_context["used_fallback"] is True
+    assert operator_context["fallback_reason"] == "tool_not_allowed"
+
+
+def test_operator_falls_back_when_confidence_is_low() -> None:
+    tool_center = ToolCenter(ExternalDataService(Settings()))
+    operator = OperatorAgent(
+        llm_service=FakeOperatorLLM(
+            {
+                "selected_tool": "sales_analytics_tool",
+                "reason": "not sure",
+                "confidence": 0.61,
+                "fallback_required": False,
+            }
+        ),
+        tool_center=tool_center,
+    )
+
+    _, tool_call, operator_context, _ = operator.execute(
+        request=WorkflowRequest(
+            workflow_type=WorkflowType.SALES_FOLLOWUP,
+            input_payload={"period": "2026-W13"},
+        ),
+        execution_profile=object(),
+    )
+
+    assert tool_call.name == "sales_analytics_tool"
+    assert operator_context["used_fallback"] is True
+    assert operator_context["fallback_reason"] == "low_confidence"
+
+
+def test_operator_falls_back_when_model_is_unavailable() -> None:
+    tool_center = ToolCenter(ExternalDataService(Settings()))
+    operator = OperatorAgent(
+        llm_service=FakeOperatorLLM(fail=True),
+        tool_center=tool_center,
+    )
+
+    _, tool_call, operator_context, llm_call = operator.execute(
+        request=WorkflowRequest(
+            workflow_type=WorkflowType.SALES_FOLLOWUP,
+            input_payload={"period": "2026-W13"},
+        ),
+        execution_profile=object(),
+    )
+
+    assert tool_call.name == "sales_analytics_tool"
+    assert operator_context["used_fallback"] is True
+    assert operator_context["fallback_reason"] == "model_error"
+    assert llm_call is None
 
 
 def test_reviewer_output_can_request_content_correction() -> None:
@@ -434,6 +557,14 @@ def test_workflow_result_records_route_decisions() -> None:
     assert "decision_source" in route_decisions[0]
     assert "used_fallback" in route_decisions[0]
     assert any(item["next_node"] == "reviewer" for item in route_decisions)
+
+
+def test_workflow_run_persists_operator_context() -> None:
+    body = create_sales_run()
+
+    assert "operator_context" in body["result"]
+    assert "executed_tool" in body["result"]["operator_context"]
+    assert "used_fallback" in body["result"]["operator_context"]
 
 
 def test_waiting_human_reasons_do_not_include_auto_execute_copy() -> None:


### PR DESCRIPTION
## Summary
- add a minimal `OperatorAgent` tool-selection loop: one structured model decision, one tool execution, and deterministic fallback
- add `OperatorDecision`, auditable `operator_context`, and named tool execution helpers on `ToolCenter`
- persist `operator_context` in run results and show it on the run detail page with a legacy empty state
- add focused TDD coverage plus design and implementation plan docs for the issue #2 clean path
- ensure model-selected `support_triage_tool` does not accidentally execute an external provider tool when `data_source` is present

## Scope
This PR replaces the older draft PR #6 with a smaller, cleaner issue #2 implementation. It does not add multi-round tool use, observe -> replan -> second tool call, dynamic agent registration, cleanup scripts, or broad UI changes.

## Validation
- `python -m pytest tests/test_workflows.py -k "operator_respects_model_selected_support_triage_tool_with_data_source" -q` -> 1 failed before fix, then covered by operator suite
- `python -m pytest tests/test_workflows.py -k "operator_respects_model_selected_support_triage_tool_with_data_source or operator" -q` -> 8 passed
- `python -m pytest tests/test_workflows.py -k "operator or workflow or run_detail_page" -q` -> 45 passed
- `python -m pytest -q` -> 46 passed
- `git diff --check origin/main...HEAD` -> clean

Refs #2
Supersedes #6