### PR TITLE
[codex] guard sales workflow when data is missing

### DIFF
--- a/app/services.py
+++ b/app/services.py
@@ -647,27 +647,54 @@ class ToolCenter:
     def _sales_analytics(self, payload: dict[str, Any]) -> dict[str, Any]:
         region = payload.get("region")
         reps = set(payload.get("sales_reps", []))
+        filters = {
+            "focus_metric": payload.get("focus_metric", "conversion_rate"),
+            "period": payload.get("period", "current"),
+            "region": region or "all",
+            "sales_reps": list(payload.get("sales_reps", [])),
+        }
         rows = [
             row for row in SALES_DATA
             if (not region or row["region"] == region) and (not reps or row["rep"] in reps)
         ]
         if not rows:
-            rows = SALES_DATA[:]
+            return {
+                "focus_metric": filters["focus_metric"],
+                "period": filters["period"],
+                "region": filters["region"],
+                "lead_count": 0,
+                "qualified_leads": 0,
+                "deals": 0,
+                "conversion_rate": None,
+                "avg_cycle_days": None,
+                "risk_customers": [],
+                "data_status": "no_match",
+                "matched_rows": 0,
+                "source": "demo_sales_data",
+                "filters": filters,
+                "fallback_reason": "no_sales_rows_matched_filters",
+                "message": "未找到匹配销售数据，无法生成可信销售分析。",
+            }
         lead_count = sum(item["leads"] for item in rows)
         qualified = sum(item["qualified"] for item in rows)
         deals = sum(item["deals"] for item in rows)
         avg_cycle_days = round(mean(item["avg_cycle_days"] for item in rows), 1)
         conversion_rate = round(deals / lead_count, 2) if lead_count else 0.0
         return {
-            "focus_metric": payload.get("focus_metric", "conversion_rate"),
-            "period": payload.get("period", "current"),
-            "region": region or "all",
+            "focus_metric": filters["focus_metric"],
+            "period": filters["period"],
+            "region": filters["region"],
             "lead_count": lead_count,
             "qualified_leads": qualified,
             "deals": deals,
             "conversion_rate": conversion_rate,
             "avg_cycle_days": avg_cycle_days,
             "risk_customers": [item for item in RISK_CUSTOMERS if not reps or item["owner"] in reps],
+            "data_status": "matched",
+            "matched_rows": len(rows),
+            "source": "demo_sales_data",
+            "filters": filters,
+            "fallback_reason": None,
         }
 
     @staticmethod
@@ -775,6 +802,8 @@ class AnalystAgent:
         prompt_profile: PromptProfile,
     ) -> tuple[dict[str, Any], Any]:
         fallback = self._fallback_analysis(request.workflow_type, raw_result)
+        if request.workflow_type == WorkflowType.SALES_FOLLOWUP and raw_result.get("data_status") == "no_match":
+            return fallback, None
         system_prompt = (
             "你是企业 AI 工作流中的 AnalystAgent。请严格返回 JSON，键为 summary、insights、action_plan，全部使用中文。"
         )
@@ -801,6 +830,19 @@ class AnalystAgent:
     @staticmethod
     def _fallback_analysis(workflow_type: WorkflowType, raw_result: dict[str, Any]) -> dict[str, Any]:
         if workflow_type == WorkflowType.SALES_FOLLOWUP:
+            if raw_result.get("data_status") == "no_match":
+                filters = raw_result.get("filters", {})
+                return {
+                    "summary": "未找到匹配销售数据，无法生成可信销售分析。",
+                    "insights": [
+                        f"请求条件未命中销售数据：{json.dumps(filters, ensure_ascii=False)}。",
+                        "当前结果不能作为区域、人员或周期维度的销售判断依据。",
+                    ],
+                    "action_plan": [
+                        "补充或校正销售数据后重新运行工作流。",
+                        "确认输入的区域、销售负责人和统计周期是否存在于数据源中。",
+                    ],
+                }
             risk_names = "、".join(item["name"] for item in raw_result.get("risk_customers", [])) or "暂无"
             return {
                 "summary": (
@@ -976,6 +1018,8 @@ class ContentAgent:
         prompt_profile: PromptProfile,
     ) -> tuple[dict[str, Any], Any]:
         fallback = self._fallback_deliverables(request.workflow_type, raw_result, analysis)
+        if request.workflow_type == WorkflowType.SALES_FOLLOWUP and raw_result.get("data_status") == "no_match":
+            return fallback, None
         system_prompt = (
             "你是企业 AI 工作流中的 ContentAgent。请严格返回 JSON，键为 deliverables 和 manager_note，全部使用中文。"
         )
@@ -1006,18 +1050,26 @@ class ContentAgent:
         analysis: dict[str, Any],
     ) -> dict[str, Any]:
         if workflow_type == WorkflowType.SALES_FOLLOWUP:
-            deliverables = {
-                "日报摘要": analysis.get("summary", ""),
-                "follow_up_plan": [
-                    {
-                        "客户": item["name"],
-                        "负责人": item["owner"],
-                        "下一步动作": item["next_action"],
-                    }
-                    for item in raw_result.get("risk_customers", [])
-                ],
-            }
-            manager_note = "需要管理者确认风险客户跟进节奏和较长销售周期的处理策略。"
+            if raw_result.get("data_status") == "no_match":
+                deliverables = {
+                    "data_gap": "未找到匹配销售数据",
+                    "requested_filters": raw_result.get("filters", {}),
+                    "follow_up_plan": [],
+                }
+                manager_note = "缺少匹配销售数据，不能生成跟进计划；请先补充或校正数据源。"
+            else:
+                deliverables = {
+                    "日报摘要": analysis.get("summary", ""),
+                    "follow_up_plan": [
+                        {
+                            "客户": item["name"],
+                            "负责人": item["owner"],
+                            "下一步动作": item["next_action"],
+                        }
+                        for item in raw_result.get("risk_customers", [])
+                    ],
+                }
+                manager_note = "需要管理者确认风险客户跟进节奏和较长销售周期的处理策略。"
         elif workflow_type == WorkflowType.MARKETING_CAMPAIGN:
             deliverables = {
                 "渠道内容资产": {
@@ -1063,6 +1115,8 @@ class ReviewerAgent:
         prompt_profile: PromptProfile,
     ) -> tuple[dict[str, Any], Any]:
         fallback = self._rule_review(request.workflow_type, raw_result, analysis, deliverables)
+        if request.workflow_type == WorkflowType.SALES_FOLLOWUP and raw_result.get("data_status") == "no_match":
+            return fallback, None
         system_prompt = (
             "你是企业 AI 工作流中的 ReviewerAgent。请严格返回 JSON，键为 status、needs_human_review、"
             "score、reasons、correction_target、correction_reason，全部使用中文。"
@@ -1099,7 +1153,11 @@ class ReviewerAgent:
         needs_human_review = False
         score = 0.88
         if workflow_type == WorkflowType.SALES_FOLLOWUP:
-            if raw_result.get("conversion_rate", 0) <= 0.15:
+            if raw_result.get("data_status") == "no_match":
+                needs_human_review = True
+                reasons.append("未找到匹配销售数据，当前结果不能作为业务决策依据。")
+                score = 0.4
+            elif raw_result.get("conversion_rate", 0) <= 0.15:
                 needs_human_review = True
                 reasons.append("当前转化率偏低，跟进策略需要管理者确认。")
                 score = 0.65

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -8,7 +8,7 @@ from app.db import UserAccountRecord
 from app.external_data import ExternalDataService
 from app.main import app, database, repository
 from app.models import ReviewDecision, ReviewOutput, RunStatus, WorkflowRequest, WorkflowRun, WorkflowType
-from app.services import OperatorAgent, ReviewerAgent, RouterAgent, ToolCenter
+from app.services import AnalystAgent, OperatorAgent, ReviewerAgent, RouterAgent, ToolCenter
 
 
 client = TestClient(app)
@@ -193,6 +193,33 @@ def test_sales_workflow_runs_with_selected_model_prompt_and_routing() -> None:
     llm_logs = [log for log in body["logs"] if log.get("llm_call")]
     assert len(llm_logs) == 5
     assert {log["llm_call"]["route_target"] for log in llm_logs} == {"planner", "operator", "analyst", "content", "reviewer"}
+
+
+def test_sales_workflow_with_no_matching_data_does_not_claim_metrics() -> None:
+    login_as("operator", "operator123")
+    response = client.post(
+        "/api/workflows/run",
+        json={
+            "workflow_type": "sales_followup",
+            "input_payload": {
+                "focus_metric": "conversion_rate",
+                "period": "2024",
+                "region": "广东深圳",
+                "sales_reps": ["阿文达", "DeathGun"],
+            },
+        },
+    )
+    body = response.json()
+
+    assert response.status_code == 200
+    assert body["status"] == "waiting_human"
+    assert body["result"]["raw_result"]["data_status"] == "no_match"
+    assert body["result"]["raw_result"]["matched_rows"] == 0
+    assert body["result"]["analysis"]["summary"] == "未找到匹配销售数据，无法生成可信销售分析。"
+    assert "转化率为" not in body["result"]["analysis"]["summary"]
+    assert body["result"]["deliverables"]["deliverables"]["data_gap"] == "未找到匹配销售数据"
+    assert body["review"]["needs_human_review"] is True
+    assert any("未找到匹配销售数据" in reason for reason in body["review"]["reasons"])
 
 
 def test_router_requests_one_replan_when_content_is_missing() -> None:
@@ -383,6 +410,75 @@ def test_operator_respects_model_selected_support_triage_tool_with_data_source()
     assert operator_context["selected_tool"] == "support_triage_tool"
     assert operator_context["executed_tool"] == "support_triage_tool"
     assert raw_result["tickets"][0]["customer"] == "ACME"
+
+
+def test_sales_tool_returns_no_match_instead_of_demo_rollup() -> None:
+    tool_center = ToolCenter(ExternalDataService(Settings()))
+
+    raw_result, tool_call = tool_center.run(
+        WorkflowType.SALES_FOLLOWUP,
+        {
+            "focus_metric": "conversion_rate",
+            "period": "2024",
+            "region": "广东深圳",
+            "sales_reps": ["阿文达", "DeathGun"],
+        },
+    )
+
+    assert tool_call.name == "sales_analytics_tool"
+    assert raw_result["data_status"] == "no_match"
+    assert raw_result["matched_rows"] == 0
+    assert raw_result["lead_count"] == 0
+    assert raw_result["deals"] == 0
+    assert raw_result["conversion_rate"] is None
+    assert raw_result["fallback_reason"] == "no_sales_rows_matched_filters"
+    assert raw_result["filters"]["region"] == "广东深圳"
+    assert raw_result["filters"]["sales_reps"] == ["阿文达", "DeathGun"]
+
+
+def test_sales_no_match_fallback_analysis_does_not_claim_metrics() -> None:
+    raw_result = {
+        "data_status": "no_match",
+        "matched_rows": 0,
+        "conversion_rate": None,
+        "avg_cycle_days": None,
+        "risk_customers": [],
+        "filters": {
+            "period": "2024",
+            "region": "广东深圳",
+            "sales_reps": ["阿文达", "DeathGun"],
+        },
+    }
+
+    analysis = AnalystAgent._fallback_analysis(WorkflowType.SALES_FOLLOWUP, raw_result)
+
+    assert "未找到匹配销售数据" in analysis["summary"]
+    assert "转化率为" not in analysis["summary"]
+    assert all("风险客户" not in item for item in analysis["insights"])
+    assert any("补充或校正销售数据" in item for item in analysis["action_plan"])
+
+
+def test_reviewer_requires_human_review_when_sales_data_is_missing() -> None:
+    review = ReviewerAgent._rule_review(
+        WorkflowType.SALES_FOLLOWUP,
+        {
+            "data_status": "no_match",
+            "matched_rows": 0,
+            "conversion_rate": None,
+            "filters": {
+                "period": "2024",
+                "region": "广东深圳",
+                "sales_reps": ["阿文达", "DeathGun"],
+            },
+        },
+        {"summary": "未找到匹配销售数据，无法生成可信分析。"},
+        {"deliverables": {"data_gap": "missing sales rows"}},
+    )
+
+    assert review["status"] == "waiting_human"
+    assert review["needs_human_review"] is True
+    assert review["score"] <= 0.5
+    assert any("未找到匹配销售数据" in reason for reason in review["reasons"])
 
 
 def test_operator_falls_back_when_selected_tool_is_not_allowed() -> None:


### PR DESCRIPTION
﻿## 变更说明
- 修复 `sales_followup` 在过滤条件无匹配记录时静默回退到全量 demo 数据的问题
- 为销售工具输出增加数据可信度字段：`data_status`、`matched_rows`、`filters`、`source`、`fallback_reason`
- 当销售数据为 `no_match` 时，`AnalystAgent` / `ContentAgent` / `ReviewerAgent` 走保守输出，不再让模型生成看似合理但无数据依据的结论
- 增加单元测试和端到端工作流测试，覆盖“广东深圳 / 阿文达 / DeathGun”这类无匹配数据场景

## 为什么改
用户输入的销售 JSON 本质上是查询条件，不是销售事实本身。旧实现中，如果这些条件在内置销售数据里没有命中记录，系统会自动使用全部 demo 数据继续计算转化率，导致页面显示出像“13% 转化率”这样的貌似有依据的结论。

这会误导用户，以为系统分析的是自己输入的地区、人员和周期。修复后，无匹配数据会明确进入 `no_match` 状态，并要求人工补充或校正数据。

## 范围
本 PR 只修销售工作流的数据缺失保护：
- 不接入新销售数据源
- 不重做 run detail UI
- 不做多轮 tool use
- 不改 RouterAgent 决策逻辑

后续工作已拆分：
- #20：run detail 展示数据状态和来源
- #18：统一所有工具的数据可信度 contract
- #19：为 `sales_followup` 接入可配置销售数据源
- #16：之后再做 bounded multi-step operator observe loop

## 验证
- `python -m pytest tests/test_workflows.py -k "sales_workflow_with_no_matching_data or sales_tool_returns_no_match or sales_no_match or reviewer_requires_human_review_when_sales_data_is_missing" -q` -> 4 passed
- `python -m pytest tests/test_workflows.py -k "sales or operator or workflow" -q` -> 50 passed
- `python -m pytest -q` -> 50 passed
- `git diff --check` -> clean
