### PR TITLE
[codex] show data provenance on run detail

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -319,6 +319,49 @@ def _build_operator_context_section(run: WorkflowRun) -> dict[str, object]:
     }
 
 
+def _format_provenance_value(value: object) -> str:
+    if value is None or value == "":
+        return "--"
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, ensure_ascii=False)
+    return str(value)
+
+
+def _build_data_provenance_section(run: WorkflowRun) -> dict[str, object]:
+    if not isinstance(run.result, dict):
+        return {"present": False}
+
+    raw_result = run.result.get("raw_result", {})
+    if not isinstance(raw_result, dict):
+        return {"present": False}
+
+    provenance_keys = {"data_status", "matched_rows", "source", "fallback_reason", "filters"}
+    if not any(key in raw_result for key in provenance_keys):
+        return {"present": False}
+
+    filters = raw_result.get("filters", {})
+    filter_rows: list[dict[str, str]] = []
+    if isinstance(filters, dict):
+        filter_rows = [
+            {"key": str(key), "value": _format_provenance_value(value)}
+            for key, value in filters.items()
+        ]
+    elif filters:
+        filter_rows = [{"key": "filters", "value": _format_provenance_value(filters)}]
+
+    data_status = str(raw_result.get("data_status") or "unknown")
+    return {
+        "present": True,
+        "data_status": data_status,
+        "matched_rows": _format_provenance_value(raw_result.get("matched_rows")),
+        "source": _format_provenance_value(raw_result.get("source")),
+        "fallback_reason": _format_provenance_value(raw_result.get("fallback_reason")),
+        "filters": filter_rows,
+        "message": str(raw_result.get("message") or ""),
+        "needs_attention": data_status in {"no_match", "fallback", "partial", "error"},
+    }
+
+
 def _build_run_rows(runs: list[WorkflowRun]) -> list[dict]:
     titles = _workflow_titles()
     rows = []
@@ -642,6 +685,7 @@ def run_detail_page(run_id: str, request: Request):
             runtime_memory_sections=_build_runtime_memory_sections(run),
             route_trace=_build_route_trace_sections(run),
             operator_context=_build_operator_context_section(run),
+            data_provenance=_build_data_provenance_section(run),
             result_json=_pretty_json(run.result),
             graph=engine.graph_shape(),
         ),

--- a/app/templates/run_detail.html
+++ b/app/templates/run_detail.html
@@ -140,6 +140,51 @@
   {% endif %}
 </section>
 
+<section class="card" style="margin-top:18px;">
+  <div class="toolbar" style="justify-content:space-between;">
+    <h2 style="margin:0;">Data Provenance</h2>
+    {% if data_provenance.present %}
+    <div class="toolbar">
+      <span class="badge">data_status: {{ data_provenance.data_status }}</span>
+      {% if data_provenance.needs_attention %}<span class="badge">NO TRUSTED DATA</span>{% endif %}
+    </div>
+    {% endif %}
+  </div>
+  {% if data_provenance.present %}
+  <div class="grid three" style="margin-top:16px;">
+    <div class="card">
+      <div class="subtle">matched_rows</div>
+      <div><strong>{{ data_provenance.matched_rows }}</strong></div>
+    </div>
+    <div class="card">
+      <div class="subtle">source</div>
+      <div><strong>{{ data_provenance.source }}</strong></div>
+    </div>
+    <div class="card">
+      <div class="subtle">fallback_reason</div>
+      <div><strong>{{ data_provenance.fallback_reason }}</strong></div>
+    </div>
+  </div>
+  {% if data_provenance.message %}
+  <div class="subtle" style="margin-top:12px;">{{ data_provenance.message }}</div>
+  {% endif %}
+  <div style="margin-top:12px;">
+    <strong>filters</strong>
+    {% if data_provenance.filters %}
+    <div class="stack" style="margin-top:10px;">
+      {% for row in data_provenance.filters %}
+      <div class="subtle">{{ row.key }}: {{ row.value }}</div>
+      {% endfor %}
+    </div>
+    {% else %}
+    <div class="subtle" style="margin-top:8px;">No filters recorded.</div>
+    {% endif %}
+  </div>
+  {% else %}
+  <div class="subtle" style="margin-top:12px;">No data provenance recorded (legacy run).</div>
+  {% endif %}
+</section>
+
 <div class="grid two" style="margin-top:18px;">
   <section class="card">
     <h2>执行日志</h2>

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -906,6 +906,69 @@ def test_run_detail_page_handles_missing_operator_context() -> None:
     assert "No operator context recorded (legacy run)." in detail.text
 
 
+def test_run_detail_page_shows_data_provenance_when_present() -> None:
+    run = WorkflowRun(
+        workflow_type=WorkflowType.SALES_FOLLOWUP,
+        status=RunStatus.WAITING_HUMAN,
+        current_step="reviewer",
+        objective="No matching sales data fixture",
+        result={
+            "raw_result": {
+                "data_status": "no_match",
+                "matched_rows": 0,
+                "source": "demo_sales_data",
+                "fallback_reason": "no_sales_rows_matched_filters",
+                "filters": {
+                    "period": "2024",
+                    "region": "广东深圳",
+                    "sales_reps": ["阿文达", "DeathGun"],
+                },
+                "message": "未找到匹配销售数据，无法生成可信销售分析。",
+            }
+        },
+    )
+    repository.save(run)
+    login_as("viewer", "viewer123")
+
+    detail = client.get(f"/runs/{run.id}")
+
+    assert detail.status_code == 200
+    assert "Data Provenance" in detail.text
+    assert "NO TRUSTED DATA" in detail.text
+    assert "data_status" in detail.text
+    assert "no_match" in detail.text
+    assert "matched_rows" in detail.text
+    assert "0" in detail.text
+    assert "source" in detail.text
+    assert "demo_sales_data" in detail.text
+    assert "fallback_reason" in detail.text
+    assert "no_sales_rows_matched_filters" in detail.text
+    assert "filters" in detail.text
+    assert "广东深圳" in detail.text
+    assert "阿文达" in detail.text
+    assert "DeathGun" in detail.text
+    assert "未找到匹配销售数据" in detail.text
+
+
+def test_run_detail_page_handles_missing_data_provenance_for_legacy_run() -> None:
+    run = WorkflowRun(
+        workflow_type=WorkflowType.SALES_FOLLOWUP,
+        status=RunStatus.COMPLETED,
+        current_step="completed",
+        objective="Legacy run without data provenance",
+        result={"raw_result": {"lead_count": 12}},
+    )
+    repository.save(run)
+    login_as("viewer", "viewer123")
+
+    detail = client.get(f"/runs/{run.id}")
+
+    assert detail.status_code == 200
+    assert "Data Provenance" in detail.text
+    assert "No data provenance recorded (legacy run)." in detail.text
+    assert "JSON" in detail.text
+
+
 def test_workflow_export_endpoint_supports_markdown_html_and_pdf() -> None:
     created = create_sales_run()
     markdown = client.get(f"/runs/{created['id']}/export?format=markdown")


### PR DESCRIPTION
﻿## 变更说明
- 在 run detail 页面新增 `Data Provenance` 区块，直接展示 `data_status`、`matched_rows`、`source`、`fallback_reason` 和 `filters`
- 对 `no_match` / `fallback` / `partial` / `error` 状态显示 `NO TRUSTED DATA` 提示，避免用户只看结论而忽略数据缺口
- 对旧 run 或缺少可信度字段的 `raw_result` 显示兼容空状态，不抛错

## 为什么改
PR #17 已经让 `sales_followup` 在无匹配销售数据时返回明确的 `no_match` contract，但此前用户仍需要打开结果 JSON 才能确认数据是否可信。这个 PR 把关键数据状态提升到 run detail 页面，减少误读风险。

## 范围
- 只读展示 `run.result.raw_result` 中已有字段
- 不改 RouterAgent 决策逻辑
- 不接入新数据源
- 不重做 run detail 整体 UI

## 验证
- `python -m pytest tests/test_workflows.py -k "data_provenance" -q` -> 2 passed
- `python -m pytest tests/test_workflows.py -k "run_detail_page" -q` -> 9 passed
- `python -m pytest -q` -> 52 passed
- `git diff --check` -> clean
- 本地 FastAPI 运行检查：登录、创建 sales no-match run、打开 run detail，页面包含 `Data Provenance` / `data_status: no_match` / `NO TRUSTED DATA` / `matched_rows` / `source` / `fallback_reason` / `filters`

Closes #20
