### PR TITLE
[codex] standardize tool data provenance

### DIFF
--- a/app/services.py
+++ b/app/services.py
@@ -601,6 +601,27 @@ class ToolCenter:
     def __init__(self, external_data: ExternalDataService) -> None:
         self.external_data = external_data
 
+    @staticmethod
+    def _provenance(
+        *,
+        data_status: str,
+        matched_rows: int,
+        source: str,
+        filters: dict[str, Any],
+        fallback_reason: str | None = None,
+        message: str | None = None,
+    ) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "data_status": data_status,
+            "matched_rows": matched_rows,
+            "source": source,
+            "filters": filters,
+            "fallback_reason": fallback_reason,
+        }
+        if message:
+            result["message"] = message
+        return result
+
     def run(self, workflow_type: WorkflowType, payload: dict[str, Any]) -> tuple[dict[str, Any], ToolCall]:
         return self.run_named(self.default_tool_for(workflow_type, payload), payload)
 
@@ -712,6 +733,16 @@ class ToolCenter:
                 "发布前复核产品能力表述",
             ],
             "channel_notes": {channel: f"为 {channel} 准备一个主卖点和一个行动号召" for channel in channels},
+            **ToolCenter._provenance(
+                data_status="matched",
+                matched_rows=len(channels),
+                source="request_payload",
+                filters={
+                    "product_name": payload.get("product_name", "目标产品"),
+                    "audience": payload.get("audience", "目标人群"),
+                    "channels": channels,
+                },
+            ),
         }
 
     def _support_triage(self, payload: dict[str, Any], *, use_external_source: bool = True) -> tuple[dict[str, Any], str]:
@@ -719,13 +750,19 @@ class ToolCenter:
         data_source = payload.get("data_source")
         tool_name = "support_triage_tool"
         source_summary: dict[str, Any] = {}
+        source = "request_payload"
+        fallback_reason = None
         if use_external_source and isinstance(data_source, dict) and data_source.get("provider"):
+            provider = str(data_source.get("provider", "")).strip()
+            source = provider or "external_source"
             try:
                 batch = self.external_data.load_support_tickets(data_source)
                 tickets = batch.records
                 tool_name = f"{batch.provider}_tool"
+                source = batch.provider
                 source_summary = {"provider": batch.provider, **batch.summary}
             except ExternalDataError as exc:
+                fallback_reason = str(exc)
                 source_summary = {
                     "provider": str(data_source.get("provider", "")),
                     "error": str(exc),
@@ -762,6 +799,28 @@ class ToolCenter:
             "high_priority_count": sum(1 for item in enriched if item["priority"] == "high"),
             "requires_incident_handoff": any(item["category"] == "incident" for item in enriched),
             "data_source_summary": source_summary,
+            **self._provenance(
+                data_status=(
+                    "fallback"
+                    if source_summary.get("fallback_to_sample")
+                    else "matched"
+                    if enriched
+                    else "no_match"
+                ),
+                matched_rows=len(enriched),
+                source=source,
+                filters={
+                    "provider": source_summary.get("provider") or source,
+                    "ticket_count": len(enriched),
+                },
+                fallback_reason=(
+                    fallback_reason
+                    if fallback_reason
+                    else None
+                    if enriched
+                    else "no_support_tickets_provided"
+                ),
+            ),
         }
         return result, tool_name
 
@@ -785,6 +844,14 @@ class ToolCenter:
             "action_items": actions,
             "owner_count": len({item["owner"] for item in actions}),
             "summary_points": sentences[:3],
+            **ToolCenter._provenance(
+                data_status="matched" if actions else "no_match",
+                matched_rows=len(actions),
+                source="request_payload",
+                filters={"meeting_title": payload.get("meeting_title", "浼氳")},
+                fallback_reason=None if actions else "no_meeting_action_items_extracted",
+                message=None if actions else "No meeting action items were extracted from the provided notes.",
+            ),
         }
 
 
@@ -1177,6 +1244,16 @@ class ReviewerAgent:
                 needs_human_review = True
                 reasons.append("当前未抽取到清晰的行动项，需要人工确认。")
                 score = 0.55
+
+        data_status = raw_result.get("data_status")
+        if data_status in {"no_match", "partial", "fallback", "error"}:
+            needs_human_review = True
+            score = min(score, 0.55)
+            source = raw_result.get("source") or "unknown"
+            fallback_reason = raw_result.get("fallback_reason") or "--"
+            reasons.append(
+                f"data_status={data_status} from {source} requires human review; fallback_reason={fallback_reason}."
+            )
 
         if not reasons:
             reasons.append("结果结构完整，可直接流转执行。")

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -5,7 +5,7 @@ from fastapi.testclient import TestClient
 
 from app.config import Settings
 from app.db import UserAccountRecord
-from app.external_data import ExternalDataService
+from app.external_data import ExternalDataError, ExternalDataService
 from app.main import app, database, repository
 from app.models import ReviewDecision, ReviewOutput, RunStatus, WorkflowRequest, WorkflowRun, WorkflowType
 from app.services import AnalystAgent, OperatorAgent, ReviewerAgent, RouterAgent, ToolCenter
@@ -479,6 +479,107 @@ def test_reviewer_requires_human_review_when_sales_data_is_missing() -> None:
     assert review["needs_human_review"] is True
     assert review["score"] <= 0.5
     assert any("未找到匹配销售数据" in reason for reason in review["reasons"])
+
+
+def test_non_sales_tools_return_standard_data_provenance_contracts() -> None:
+    tool_center = ToolCenter(ExternalDataService(Settings()))
+
+    marketing_result, marketing_call = tool_center.run(
+        WorkflowType.MARKETING_CAMPAIGN,
+        {
+            "product_name": "FlowPilot",
+            "audience": "ops teams",
+            "channels": ["email", "linkedin"],
+            "key_benefits": ["faster triage"],
+        },
+    )
+    support_result, support_call = tool_center.run(
+        WorkflowType.SUPPORT_TRIAGE,
+        {"tickets": [{"customer": "ACME", "message": "production outage"}]},
+    )
+    meeting_result, meeting_call = tool_center.run(
+        WorkflowType.MEETING_MINUTES,
+        {"meeting_title": "Launch sync", "notes": "1. Alice confirm rollout plan"},
+    )
+
+    assert marketing_call.name == "marketing_brief_tool"
+    assert marketing_result["data_status"] == "matched"
+    assert marketing_result["matched_rows"] == 2
+    assert marketing_result["source"] == "request_payload"
+    assert marketing_result["fallback_reason"] is None
+    assert marketing_result["filters"]["channels"] == ["email", "linkedin"]
+
+    assert support_call.name == "support_triage_tool"
+    assert support_result["data_status"] == "matched"
+    assert support_result["matched_rows"] == 1
+    assert support_result["source"] == "request_payload"
+    assert support_result["fallback_reason"] is None
+    assert support_result["filters"]["ticket_count"] == 1
+
+    assert meeting_call.name == "meeting_minutes_tool"
+    assert meeting_result["data_status"] == "matched"
+    assert meeting_result["matched_rows"] == 1
+    assert meeting_result["source"] == "request_payload"
+    assert meeting_result["fallback_reason"] is None
+    assert meeting_result["filters"]["meeting_title"] == "Launch sync"
+
+
+def test_support_external_data_failure_is_marked_as_fallback() -> None:
+    class FailingExternalData(ExternalDataService):
+        def load_support_tickets(self, source: dict) -> object:
+            raise ExternalDataError("provider unavailable")
+
+    tool_center = ToolCenter(FailingExternalData(Settings()))
+
+    raw_result, tool_call = tool_center.run_named(
+        "github_issues_tool",
+        {
+            "tickets": [{"customer": "ACME", "message": "production outage"}],
+            "data_source": {"provider": "github_issues", "repo": "acme/app"},
+        },
+    )
+
+    assert tool_call.name == "support_triage_tool"
+    assert raw_result["data_status"] == "fallback"
+    assert raw_result["matched_rows"] == 1
+    assert raw_result["source"] == "github_issues"
+    assert raw_result["fallback_reason"] == "provider unavailable"
+    assert raw_result["filters"]["provider"] == "github_issues"
+
+
+def test_meeting_tool_returns_no_match_when_no_action_items_are_extracted() -> None:
+    tool_center = ToolCenter(ExternalDataService(Settings()))
+
+    raw_result, tool_call = tool_center.run(
+        WorkflowType.MEETING_MINUTES,
+        {"meeting_title": "Empty sync", "notes": ""},
+    )
+
+    assert tool_call.name == "meeting_minutes_tool"
+    assert raw_result["data_status"] == "no_match"
+    assert raw_result["matched_rows"] == 0
+    assert raw_result["source"] == "request_payload"
+    assert raw_result["fallback_reason"] == "no_meeting_action_items_extracted"
+
+
+def test_reviewer_requires_human_review_for_untrusted_tool_data_status() -> None:
+    review = ReviewerAgent._rule_review(
+        WorkflowType.SUPPORT_TRIAGE,
+        {
+            "data_status": "fallback",
+            "matched_rows": 1,
+            "source": "github_issues",
+            "fallback_reason": "provider unavailable",
+            "tickets": [{"category": "general_inquiry"}],
+        },
+        {"summary": "external source unavailable"},
+        {"deliverables": {"reply_drafts": []}},
+    )
+
+    assert review["status"] == "waiting_human"
+    assert review["needs_human_review"] is True
+    assert review["score"] <= 0.55
+    assert any("fallback" in reason for reason in review["reasons"])
 
 
 def test_operator_falls_back_when_selected_tool_is_not_allowed() -> None:


### PR DESCRIPTION
﻿## 变更说明
- 为非 sales 工具补齐统一数据可信度 contract：`data_status`、`matched_rows`、`source`、`filters`、`fallback_reason`
- `marketing_brief` 标记为 `matched`，来源为 `request_payload`，匹配数按渠道数记录
- `support_triage` 标记本地 payload、外部 provider、外部 provider 失败后的 fallback，并记录 provider / ticket_count
- `meeting_minutes` 有行动项时标记 `matched`，无行动项时标记 `no_match`
- Reviewer 对 `no_match` / `partial` / `fallback` / `error` 统一要求人工审核，并压低评分上限

## 为什么改
PR #17 先解决了 sales no-data guard，PR #21 把数据状态展示到 run detail。这个 PR 把相同 contract 推广到其他工具，避免不同 workflow 对数据来源和无数据状态的表达不一致。

## 范围
- 只标准化工具输出和 Reviewer 的保守审核规则
- 不接新数据源
- 不做多轮 tool use
- 不改 RouterAgent 决策逻辑
- 不做 UI 大改，沿用 #21 的 run detail 展示能力

## 验证
- `python -m pytest tests/test_workflows.py -k "standard_data_provenance or external_data_failure_is_marked or no_action_items_are_extracted or untrusted_tool_data_status" -q` -> 4 passed
- `python -m pytest tests/test_workflows.py -k "sales or support or marketing or meeting or workflow or data_provenance" -q` -> 56 passed
- `python -m pytest -q` -> 56 passed
- `git diff --check` -> clean

Closes #18
